### PR TITLE
Add residencial report interface and export

### DIFF
--- a/src/interfaces/gas/resumen-reportes/valores reporte/index.ts
+++ b/src/interfaces/gas/resumen-reportes/valores reporte/index.ts
@@ -1,3 +1,4 @@
 export * from "./valoresReporte";
 export * from "./nsp";
 export * from "./veribox";
+export * from "./residencial";

--- a/src/interfaces/gas/resumen-reportes/valores reporte/residencial.ts
+++ b/src/interfaces/gas/resumen-reportes/valores reporte/residencial.ts
@@ -1,0 +1,10 @@
+export interface IResumenReporteResidencial {
+  timestamp?: string;
+  consumoMin?: number;
+  consumoMax?: number;
+  consumoProm?: number;
+  unidad: string;
+  bateriaMin?: number;
+  bateriaMax?: number;
+  bateriaProm?: number;
+}

--- a/src/interfaces/gas/resumen-reportes/valores reporte/valoresReporte.ts
+++ b/src/interfaces/gas/resumen-reportes/valores reporte/valoresReporte.ts
@@ -1,6 +1,8 @@
 import { IResumenReporteNSP } from "./nsp";
 import { IResumenReporteVeribox } from "./veribox";
+import { IResumenReporteResidencial } from "./residencial";
 
 export type IValoresResumenReporte =
   | IResumenReporteNSP
-  | IResumenReporteVeribox;
+  | IResumenReporteVeribox
+  | IResumenReporteResidencial;


### PR DESCRIPTION
Introduces IResumenReporteResidencial interface for residential report values and updates exports and type definitions to include it in the resumen reportes module.