### PR TITLE
Add 'Residencial Agua' to Division type

### DIFF
--- a/src/interfaces/tenant/usuario/permiso.ts
+++ b/src/interfaces/tenant/usuario/permiso.ts
@@ -19,6 +19,7 @@ export type Division =
   | "Correctoras"
   | "Presión"
   | "Residencial"
+  | "Residencial Agua"
   | "SCADA Unifilares"
   | "SCADA Mediciones";
 


### PR DESCRIPTION
Extended the Division type to include the new value 'Residencial Agua' for improved categorization.