### PR TITLE
Add titular interface to medidor residencial agua

### DIFF
--- a/src/interfaces/entidades/medidor-residencial-agua.ts
+++ b/src/interfaces/entidades/medidor-residencial-agua.ts
@@ -7,6 +7,17 @@ import { IGrupo } from "./grupo";
 import { ILocalidad } from "./localidad";
 import { IReporte } from "./reporte";
 
+export interface ITitularMedidorResidencialAgua {
+  nombre?: string;
+  tipo: "persona" | "empresa";
+  documento?: string; // DNI o CUIT
+  tipoDocumento?: "DNI" | "CUIT";
+  telefono?: string;
+  email?: string;
+  // Estado
+  activo?: boolean;
+}
+
 export interface IMedidorResidencialAgua {
   _id?: string;
   //
@@ -23,6 +34,7 @@ export interface IMedidorResidencialAgua {
   direccion?: string;
   nombre?: string;
   descripcion?: string;
+  titular?: ITitularMedidorResidencialAgua;
   corregido?: boolean;
   //
   idCliente?: string;


### PR DESCRIPTION
Introduced the ITitularMedidorResidencialAgua interface to represent the owner of a residential water meter and added an optional 'titular' property to the IMedidorResidencialAgua interface. This allows for more detailed information about the meter's owner, including name, type, document, contact info, and status.