### PR TITLE
fix(IReporteScada): permitir valorActual boolean además de number

### DIFF
--- a/src/interfaces/entidades/valores-reporte/scada.ts
+++ b/src/interfaces/entidades/valores-reporte/scada.ts
@@ -9,7 +9,7 @@ import { TipoScada } from '../scada';
 export interface IReporteScada {
   tipo?: TipoScada;
   timestamp?: string;
-  valorActual?: number;
+  valorActual?: number | boolean;
   limiteHH?: number | null;
   limiteH?: number | null;
   limiteLL?: number | null;


### PR DESCRIPTION
## Summary
- Amplía `IReporteScada.valorActual` de `number` a `number | boolean`.
- Los tags OPC-UA de tipo Boolean se serializan como `true`/`false` nativos al ser enviados por `gas-opcua-externo`; el tipo anterior forzaba castings o desalineaba el contrato real.

## Contexto
Reportado por Daniel Beresvil (Camuzzi) el 2026-04-17: las alertas/notificaciones para tags booleanos (p. ej. "Alimentación 220V" en ERP PIO) no se generaban a pesar de que el estado cambiaba en UI.

Al auditar producción (cliente Camuzzi):
- 43 alertas BOOLEANO activas sin movimiento desde mayo 2025.
- POST entrantes `.../reportesOPC` llegan con `valorActual: false` / `valorActual: true` (boolean JSON nativo).
- Consumidor (`gas-api-integraciones`) comparaba `valorActual === 1` → nunca matcheaba y la lógica quedaba trabada.

## Cambio
```diff
- valorActual?: number;
+ valorActual?: number | boolean;
```

## Repos impactados
Consumidores principales a revisar / alinear:
- `gas-api-integraciones` → PR de fix asociado.
- `gas-datos`, `gas-web-cliente`, `gas-web-admin` → el cambio es aditivo, no debería romper compilación.

## Test plan
- [ ] Verificar que los consumers compilen con la nueva definición (`yarn build` en cada repo que importe el tipo).
- [ ] Release como nueva versión del paquete `modelos` y bump en `gas-api-integraciones`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)