### PR TITLE
feat: rol TecnicoCampo y flag puedeCrearDispositivos

### DIFF
--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -80,6 +80,13 @@ export interface IConfigCliente {
    * A nivel global genera alertas de batería baja para los dispositivos SML con bateria menor al valor definido
    */
   valorAlarmaBateriaSml?: number;
+
+  /**
+   * Si es true, los usuarios del cliente con rol TecnicoCampo o Administrador pueden crear dispositivos
+   * vía el flujo de la app móvil (POST /dispositivos en gas-api-cliente). Default: false.
+   * Pensado para habilitar la alta de medidores ML107A en campo, leyendo las keys LoRaWAN por NFC.
+   */
+  puedeCrearDispositivos?: boolean;
 }
 
 export interface ICliente {

--- a/src/interfaces/tenant/usuario/permiso.ts
+++ b/src/interfaces/tenant/usuario/permiso.ts
@@ -8,7 +8,8 @@ export type Rol =
   | "Usuario"
   | "Croma"
   | "Visualizar"
-  | "Laboratorista";
+  | "Laboratorista"
+  | "TecnicoCampo";
 export type Nivel =
   | "Global"
   | "Unidad de Negocio"


### PR DESCRIPTION
## Summary

- Agrega `"TecnicoCampo"` al union `Rol` en `IPermiso`.
- Agrega `IConfigCliente.puedeCrearDispositivos?: boolean` (default implícito `false`).

Ambos cambios son aditivos y no rompen consumidores existentes.

## Contexto

Primera fase (B1) del plan de habilitación backend para la app móvil `gas-mobile`. El rol `TecnicoCampo` y el flag habilitan el nuevo endpoint `POST /dispositivos` que va a exponer `gas-api-cliente` (fase B5) para que técnicos de campo registren medidores ML107A leyendo las credenciales LoRaWAN por NFC.

Plan completo: \`fuentes/gas/BACKEND-IMPLEMENTATION-PLAN.md\` (doc local, cross-repo).

Diseño detallado del contrato y RBAC:
- \`fuentes/gas/gas-mobile/BACKEND-CONTRACT.md\`
- \`fuentes/gas/gas-mobile/AUTH-AND-ROLES.md\`

## Cambios

### \`src/interfaces/tenant/usuario/permiso.ts\`

\`\`\`diff
 export type Rol =
   | "Administrador"
   | "Usuario"
   | "Croma"
   | "Visualizar"
-  | "Laboratorista";
+  | "Laboratorista"
+  | "TecnicoCampo";
\`\`\`

### \`src/interfaces/tenant/cliente.model.ts\`

Agrega al final de \`IConfigCliente\`:

\`\`\`ts
/**
 * Si es true, los usuarios del cliente con rol TecnicoCampo o Administrador
 * pueden crear dispositivos vía el flujo de la app móvil (POST /dispositivos
 * en gas-api-cliente). Default: false.
 * Pensado para habilitar la alta de medidores ML107A en campo, leyendo las
 * keys LoRaWAN por NFC.
 */
puedeCrearDispositivos?: boolean;
\`\`\`

## Impacto en consumidores

Ninguno inmediato — ambos campos son opcionales/aditivos. Una vez mergeado y tageado:

1. \`gas-datos\`: correr \`yarn run modelos\` + migration para setear el flag en \`false\` en todos los clientes existentes (fase B4).
2. \`gas-admin\`: correr \`yarn run modelos\` + (opcional) agregar el rol al selector del frontend de usuarios.
3. \`gas-api-cliente\`: correr \`yarn run modelos\` cuando se implemente la fase B5.

## Test plan

- [ ] Type check en consumidores tras el upgrade (\`yarn run modelos\`).
- [ ] No regressions en las interfaces existentes (los campos agregados son opcionales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)