### PR TITLE
feat: interfaces de cobertura LoRaWAN y gateway LoRaWAN

### DIFF
--- a/src/interfaces/entidades/cobertura-lorawan.ts
+++ b/src/interfaces/entidades/cobertura-lorawan.ts
@@ -1,0 +1,57 @@
+import { GeoJSON, ICoordenadas } from "../auxiliares";
+
+/**
+ * Recepción de un uplink de cobertura por un gateway individual.
+ */
+export interface IGatewayCobertura {
+  gatewayId?: string;
+  rssi?: number;
+  snr?: number;
+  ubicacion?: ICoordenadas;
+  /** Distancia great-circle dispositivo-gateway en metros (si el gateway tiene ubicación) */
+  distancia?: number;
+}
+
+/**
+ * Medición de cobertura LoRaWAN georeferenciada.
+ * Generada por gas-field-tester a partir de uplinks del RAK10701
+ * (field tester) u otros dispositivos con GPS.
+ */
+export interface ICoberturaLorawan {
+  _id?: string;
+  /** DevEUI del dispositivo que midió */
+  deveui?: string;
+  deviceName?: string;
+  fecha?: string;
+  /** Posición del dispositivo al momento de la medición */
+  ubicacion?: ICoordenadas;
+  /** Punto GeoJSON para queries geoespaciales (índice 2dsphere) */
+  geojson?: GeoJSON;
+  altitud?: number;
+  hdop?: number;
+  satelites?: number;
+  /** fPort del uplink (1 = corto, 11 = extendido) */
+  fPort?: number;
+  fCnt?: number;
+  /** Data rate del uplink */
+  dr?: number;
+  /** Spreading factor */
+  sf?: number;
+  /** Frecuencia en Hz */
+  frecuencia?: number;
+  /** Gateways que recibieron el uplink */
+  gateways?: IGatewayCobertura[];
+  cantidadGateways?: number;
+  minRssi?: number;
+  maxRssi?: number;
+  minSnr?: number;
+  maxSnr?: number;
+  /** Distancias en metros (solo gateways con ubicación) */
+  minDistancia?: number;
+  maxDistancia?: number;
+}
+
+// CREATE
+type OmitirCreate = "_id";
+export interface ICreateCoberturaLorawan
+  extends Omit<Partial<ICoberturaLorawan>, OmitirCreate> {}

--- a/src/interfaces/entidades/gateway-lorawan.ts
+++ b/src/interfaces/entidades/gateway-lorawan.ts
@@ -1,0 +1,40 @@
+import { ICoordenadas } from "../auxiliares";
+import { ILoraServer } from "../tenant";
+
+export type EstadoGatewayLorawan = "NEVER_SEEN" | "ONLINE" | "OFFLINE";
+
+/**
+ * Gateway LoRaWAN sincronizado desde el network server (ChirpStack v4).
+ * Mantenido por gas-field-tester (sync periódico vía API REST).
+ */
+export interface IGatewayLorawan {
+  _id?: string;
+  /** EUI64 del gateway en el network server */
+  gatewayId?: string;
+  nombre?: string;
+  descripcion?: string;
+  /** Tenant de ChirpStack al que pertenece */
+  tenantId?: string;
+  idLoraServer?: string;
+  ubicacion?: ICoordenadas;
+  altitud?: number;
+  estado?: EstadoGatewayLorawan;
+  lastSeenAt?: string;
+  /** Región/subbanda configurada (ej. au915_3) */
+  region?: string;
+  /** Última sincronización contra el network server */
+  fechaSync?: string;
+
+  // Virtuals
+  loraServer?: ILoraServer;
+}
+
+// CREATE
+type OmitirCreate = "_id" | "loraServer";
+export interface ICreateGatewayLorawan
+  extends Omit<Partial<IGatewayLorawan>, OmitirCreate> {}
+
+// UPDATE
+type OmitirUpdate = "_id" | "loraServer" | "gatewayId";
+export interface IUpdateGatewayLorawan
+  extends Omit<Partial<IGatewayLorawan>, OmitirUpdate> {}

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -38,4 +38,6 @@ export * from "./dash-general";
 export * from "./mensajes-bove";
 export * from "./gpio-config-nuc-auditoria";
 export * from "./indicadores-historicos";
+export * from "./gateway-lorawan";
+export * from "./cobertura-lorawan";
 //


### PR DESCRIPTION
## Resumen
Nuevas interfaces para el soporte de red LoRaWAN (proyecto cobertura / RAK10701 field tester):

- **`IGatewayLorawan`**: gateway sincronizado desde ChirpStack v4 — `gatewayId`, `estado` (NEVER_SEEN/ONLINE/OFFLINE), `ubicacion`, `lastSeenAt`, `region` (subbanda au915), `idLoraServer`.
- **`ICoberturaLorawan`**: medición georeferenciada de cobertura generada por el nuevo servicio `gas-field-tester` a partir de uplinks del RAK10701 — posición GPS, `geojson` (para índice 2dsphere), HDOP/satélites, fPort/fCnt/DR/SF/frecuencia, detalle por gateway (`IGatewayCobertura`: RSSI/SNR/distancia) y agregados min/max.

Consumidores: `gas-datos` (nuevas entidades), `gas-field-tester` (servicio nuevo), futura vista de cobertura en `gas-web-cliente`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)