### PR TITLE
feat: modelo de visibilidad de cobertura LoRaWAN por cliente

### DIFF
--- a/src/interfaces/entidades/asignacion-gateway-cliente.ts
+++ b/src/interfaces/entidades/asignacion-gateway-cliente.ts
@@ -1,0 +1,35 @@
+import { ICliente } from "../tenant";
+import { IGatewayLorawan } from "./gateway-lorawan";
+
+/**
+ * Asigna un gateway LoRaWAN a un cliente que tiene
+ * `config.moduloCoberturaLorawan.activo`. Relación N-a-N: un mismo gateway
+ * físico puede ser visible por varios clientes (red LoRaWAN compartida).
+ *
+ * La cobertura del cliente se filtra por los `gatewayId` (EUI64) aquí
+ * asignados, ya que `ICoberturaLorawan.gateways[]` referencia a los gateways
+ * de forma embebida por `gatewayId` (no por `_id`).
+ */
+export interface IAsignacionGatewayCliente {
+  _id?: string;
+  idCliente?: string;
+  /** `_id` del documento GatewayLorawan en gas-datos */
+  idGatewayLorawan?: string;
+  /** EUI64 denormalizado del gateway, para filtrar coberturas sin populate */
+  gatewayId?: string;
+  fechaCreacion?: string;
+
+  // Virtuals
+  cliente?: ICliente;
+  gateway?: IGatewayLorawan;
+}
+
+// CREATE
+type OmitirCreate = "_id" | "cliente" | "gateway" | "fechaCreacion";
+export interface ICreateAsignacionGatewayCliente
+  extends Omit<Partial<IAsignacionGatewayCliente>, OmitirCreate> {}
+
+// UPDATE
+type OmitirUpdate = "_id" | "cliente" | "gateway" | "fechaCreacion";
+export interface IUpdateAsignacionGatewayCliente
+  extends Omit<Partial<IAsignacionGatewayCliente>, OmitirUpdate> {}

--- a/src/interfaces/entidades/gateway-lorawan.ts
+++ b/src/interfaces/entidades/gateway-lorawan.ts
@@ -4,7 +4,7 @@ import { ILoraServer } from "../tenant";
 export type EstadoGatewayLorawan = "NEVER_SEEN" | "ONLINE" | "OFFLINE";
 
 /**
- * Gateway LoRaWAN sincronizado desde el network server (ChirpStack v4).
+ * Gateway LoRaWAN sincronizado desde el network server (ChirpStack v3/v4).
  * Mantenido por gas-field-tester (sync periódico vía API REST).
  */
 export interface IGatewayLorawan {

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -6,6 +6,7 @@ export * from "./mensajes-nuc";
 export * from "./alerta";
 export * from "./aplicacion-cromatografia";
 export * from "./asignacion";
+export * from "./asignacion-gateway-cliente";
 export * from "./config-dispositivo";
 export * from "./correctora";
 export * from "./cromatografia";

--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -128,6 +128,19 @@ export interface IVistasPersonalizadasPorDivision {
   Correctoras?: IVistaPersonalizadaCorrectoras;
 }
 
+export interface IModuloCoberturaLorawan {
+  /**
+   * Habilita la vista "Cobertura LoRaWAN" en gas-web-cliente y los endpoints
+   * asociados de gas-api-cliente. Si no está o es false, la feature está oculta.
+   */
+  activo?: boolean;
+  /**
+   * Si es true, el cliente ve métricas de gateway (proxy a ChirpStack).
+   * Default: false.
+   */
+  verMetricas?: boolean;
+}
+
 export type DivisionConVistaPersonalizada = Extract<Division, "Correctoras">;
 
 export interface IConfigCliente {
@@ -161,6 +174,13 @@ export interface IConfigCliente {
    * detalle del punto que muestra los mismos registros con columnas/agrupación configuradas.
    */
   vistasPersonalizadas?: IVistasPersonalizadasPorDivision;
+
+  /**
+   * Visualización de cobertura LoRaWAN. Habilita la vista de mapa de cobertura
+   * y la sección "LoRaWAN" de configuración para el cliente. Los gateways
+   * visibles se definen vía la colección AsignacionGatewayCliente.
+   */
+  moduloCoberturaLorawan?: IModuloCoberturaLorawan;
 }
 
 export interface ICliente {


### PR DESCRIPTION
## Qué

Modelo de datos para la **visualización de cobertura LoRaWAN multi-tenant** (plan `PLAN-COBERTURA-LORAWAN-VISUALIZACION.md`). Fase 1 de 6 — raíz de dependencias; bloquea a gas-datos, gas-admin, gas-api-cliente, gas-web-admin, gas-web-cliente.

## Cambios

- **`IModuloCoberturaLorawan`** en `IConfigCliente` (`cliente.model.ts`): flag `activo` (habilita la vista + endpoints) + `verMetricas` (proxy ChirpStack).
- **`IAsignacionGatewayCliente`** (`asignacion-gateway-cliente.ts`): relación **N-a-N** gateway↔cliente. `gatewayId` (EUI64) denormalizado para filtrar coberturas sin populate (las coberturas embeben gateways por `gatewayId`, no por `_id`). Se eligió colección intermedia dedicada en vez de `idCliente` en el gateway (red compartida ⇒ un gateway visible por varios clientes) y en vez de reutilizar `IAsignacion` (su enum es de dominio gas).
- Export en barrel de entidades.
- Corrige comentario JSDoc "ChirpStack v4" → "v3/v4" en `IGatewayLorawan` (el LNS real es v3).

## Después de mergear

`npm run modelos` en cada repo dependiente para propagar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)