### PR TITLE
feat(cobertura): modelos v2 cobertura LoRaWAN (gateways + métricas beyond-NS)

### DIFF
--- a/src/interfaces/entidades/cobertura-lorawan.ts
+++ b/src/interfaces/entidades/cobertura-lorawan.ts
@@ -8,6 +8,8 @@ export interface IGatewayCobertura {
   rssi?: number;
   snr?: number;
   ubicacion?: ICoordenadas;
+  /** Altitud del gateway en metros (de rxInfo[].location.altitude) */
+  altitud?: number;
   /** Distancia great-circle dispositivo-gateway en metros (si el gateway tiene ubicación) */
   distancia?: number;
 }
@@ -30,6 +32,10 @@ export interface ICoberturaLorawan {
   altitud?: number;
   hdop?: number;
   satelites?: number;
+  /** Precisión estimada del fix GPS en metros: (hdop*5+5)/10 */
+  accuracy?: number;
+  /** Medición sin fix GPS válido: conserva RSSI/SNR/diversidad pero no se ubica en el mapa */
+  sinFix?: boolean;
   /** fPort del uplink (1 = corto, 11 = extendido) */
   fPort?: number;
   fCnt?: number;
@@ -39,6 +45,10 @@ export interface ICoberturaLorawan {
   sf?: number;
   /** Frecuencia en Hz */
   frecuencia?: number;
+  /** Ancho de banda en Hz (de txInfo) */
+  bandwidth?: number;
+  /** Code rate (de txInfo, ej. "4/5") */
+  codeRate?: string;
   /** Gateways que recibieron el uplink */
   gateways?: IGatewayCobertura[];
   cantidadGateways?: number;

--- a/src/interfaces/entidades/estadistica-gateway-lorawan.ts
+++ b/src/interfaces/entidades/estadistica-gateway-lorawan.ts
@@ -1,0 +1,39 @@
+/**
+ * Estadística agregada de un gateway LoRaWAN en un intervalo de tiempo.
+ * Obtenida de la API de stats del network server (ChirpStack):
+ * v3 GET /api/gateways/{id}/stats, v4 GatewayService.GetMetrics.
+ *
+ * Permite métricas que el NS no resuelve por uplink: interferencia
+ * (rxCrcFail = rxReceived - rxReceivedOK) y ocupación de canal
+ * (rxPorFrecuencia / rxPorDr).
+ */
+export type IntervaloEstadisticaGateway = "MINUTE" | "HOUR" | "DAY";
+
+export interface IEstadisticaGatewayLorawan {
+  _id?: string;
+  /** EUI64 del gateway en el network server */
+  gatewayId?: string;
+  idLoraServer?: string;
+  /** Inicio del bucket de agregación */
+  fecha?: string;
+  intervalo?: IntervaloEstadisticaGateway;
+  /** Paquetes recibidos por la radio del gateway (rxPacketsReceived) */
+  rxReceived?: number;
+  /** Paquetes recibidos que pasaron CRC/decodificación (rxPacketsReceivedOK) */
+  rxReceivedOK?: number;
+  /** Derivado: rxReceived - rxReceivedOK. Proxy de interferencia/colisión. */
+  rxCrcFail?: number;
+  txReceived?: number;
+  txEmitted?: number;
+  /** Conteo de paquetes rx por frecuencia (Hz) — ocupación de canal */
+  rxPorFrecuencia?: Record<string, number>;
+  /** Conteo de paquetes rx por data rate */
+  rxPorDr?: Record<string, number>;
+  txPorFrecuencia?: Record<string, number>;
+  txPorDr?: Record<string, number>;
+}
+
+// CREATE
+type OmitirCreate = "_id";
+export interface ICreateEstadisticaGatewayLorawan
+  extends Omit<Partial<IEstadisticaGatewayLorawan>, OmitirCreate> {}

--- a/src/interfaces/entidades/gateway-lorawan.ts
+++ b/src/interfaces/entidades/gateway-lorawan.ts
@@ -18,10 +18,22 @@ export interface IGatewayLorawan {
   idLoraServer?: string;
   ubicacion?: ICoordenadas;
   altitud?: number;
+  /** Origen de la ubicación reportado por el NS (GPS = fix real, CONFIG = tipeada) */
+  locationSource?: "UNKNOWN" | "GPS" | "CONFIG" | "GEO_RESOLVER";
+  /** Precisión de la ubicación en metros (location.accuracy del NS) */
+  locationAccuracy?: number;
   estado?: EstadoGatewayLorawan;
   lastSeenAt?: string;
   /** Región/subbanda configurada (ej. au915_3) */
   region?: string;
+  /** propertiesMap completo del NS (modelo/firmware/region_config_id, etc.) */
+  propiedades?: Record<string, string>;
+  /** Fecha de alta del gateway en el NS (Gateway.createdAt, v4) */
+  createdAtNs?: string;
+  /** Fecha de última modificación en el NS (Gateway.updatedAt, v4) */
+  updatedAtNs?: string;
+  /** Intervalo de stats configurado en el NS en segundos (v4) */
+  statsInterval?: number;
   /** Última sincronización contra el network server */
   fechaSync?: string;
 

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -43,4 +43,5 @@ export * from "./gpio-config-nuc-auditoria";
 export * from "./indicadores-historicos";
 export * from "./gateway-lorawan";
 export * from "./cobertura-lorawan";
+export * from "./estadistica-gateway-lorawan";
 //


### PR DESCRIPTION
## Fase 0 — Plan Cobertura LoRaWAN v2

Primer PR del plan `PLAN-COBERTURA-LORAWAN-V2.md`. **Solo interfaces TypeScript** (gas-modelos no compila); base de todos los demás repos. Se mergea primero; recién después los consumidores bajan con `npm run modelos` + re-pin de lockfile.

### Cambios

**`cobertura-lorawan.ts`**
- `ICoberturaLorawan`: `accuracy` (precisión del fix GPS, ya se calcula en el codec y hoy se descarta), `sinFix` (mediciones sin GPS válido), `bandwidth` + `codeRate` (de `txInfo`, hoy descartados en la normalización).
- `IGatewayCobertura`: `altitud` por gateway (de `rxInfo[].location.altitude`).

**`gateway-lorawan.ts`**
- `locationSource` / `locationAccuracy` (provenance de la ubicación reportada por el NS), `propiedades` (`propertiesMap` completo, hoy solo se extrae `region_config_id`), `createdAtNs` / `updatedAtNs`, `statsInterval`.

**Nueva entidad `estadistica-gateway-lorawan.ts`** (consumida en Fase 4)
- `IEstadisticaGatewayLorawan`: serie temporal de stats por gateway. `rxReceived`/`rxReceivedOK`/`rxCrcFail` (proxy de interferencia), `rx/txPorFrecuencia` y `rx/txPorDr` (ocupación de canal).

### Notas
- Todos los campos son opcionales → no rompe consumidores existentes.
- Tras el merge: `npm run modelos` + re-pin de lockfile con install limpio en cada consumidor antes de sus PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)