### PR TITLE
feat(integracion): modelo base integración facturación (AYSAM/Manantial) — Fase 1

### DIFF
--- a/src/interfaces/entidades/cuenta-cliente.ts
+++ b/src/interfaces/entidades/cuenta-cliente.ts
@@ -1,0 +1,68 @@
+import { ICoordenadas } from "../auxiliares";
+import { ICentroOperativo, IUnidadNegocio } from "../gas";
+import { Division } from "../tenant";
+import { IPuntoMedicion } from "./punto-medicion";
+
+/**
+ * Cuenta / Inmueble — agrupador de facturación proveniente de una integración
+ * externa (p. ej. Sistema Manantial de AYSAM). Una cuenta agrupa N puntos de
+ * medición (análogo a las "conexiones" de Manantial, que cuelgan de un
+ * inmueble/cuenta). No es obligatoria: solo la usan los clientes con la
+ * integración activa (capability `IConfigCliente.gestionCuentas`). Los PMs se
+ * vinculan vía `IPuntoMedicion.idCuenta`.
+ */
+export interface ICuentaCliente {
+  _id?: string;
+  fechaCreacion?: string;
+  // Identidad
+  numeroCuenta?: string; // INM_CUENTA — único por cliente
+  titular?: string;
+  // Metadatos de inmueble (datos fijos que devuelve el sistema externo)
+  codRegimen?: number;
+  regimen?: string; // p. ej. "C.Fija + exceso"
+  coefZonal?: number;
+  baseConsumo?: number;
+  supTerreno?: number;
+  domicilio?: string;
+  ubicacion?: ICoordenadas; // coord_x / coord_y del inmueble
+  codProvincia?: number;
+  provincia?: string;
+  codDepartamento?: number;
+  departamento?: string;
+  codLocalidad?: number;
+  localidad?: string;
+  // Identidad externa (idempotencia de la ingesta)
+  codigoExternoInmueble?: string; // inm_id del sistema externo
+  // Bag para el resto de campos externos no modelados (fidelidad sin bloat)
+  datosExternos?: Record<string, any>;
+  // Estado
+  estado?: "Activa" | "Baja";
+  fechaBaja?: string | null;
+  // Tenancy
+  idCliente?: string;
+  idUnidadNegocio?: string;
+  idCentroOperativo?: string;
+  division?: Division;
+  // Virtuals
+  puntosMedicion?: IPuntoMedicion[]; // las conexiones de la cuenta
+  unidadNegocio?: IUnidadNegocio;
+  centroOperativo?: ICentroOperativo;
+}
+
+////// CREATE
+type OmitirCreate =
+  | "_id"
+  | "puntosMedicion"
+  | "unidadNegocio"
+  | "centroOperativo";
+export interface ICreateCuentaCliente
+  extends Omit<Partial<ICuentaCliente>, OmitirCreate> {}
+
+////// UPDATE
+type OmitirUpdate =
+  | "_id"
+  | "puntosMedicion"
+  | "unidadNegocio"
+  | "centroOperativo";
+export interface IUpdateCuentaCliente
+  extends Omit<Partial<ICuentaCliente>, OmitirUpdate> {}

--- a/src/interfaces/entidades/cuenta-cliente.ts
+++ b/src/interfaces/entidades/cuenta-cliente.ts
@@ -1,6 +1,7 @@
 import { ICoordenadas } from "../auxiliares";
 import { ICentroOperativo, IUnidadNegocio } from "../gas";
 import { Division } from "../tenant";
+import { ILocalidad } from "./localidad";
 import { IPuntoMedicion } from "./punto-medicion";
 
 /**
@@ -25,15 +26,18 @@ export interface ICuentaCliente {
   supTerreno?: number;
   domicilio?: string;
   ubicacion?: ICoordenadas; // coord_x / coord_y del inmueble
-  codProvincia?: number;
+  // Provincia y departamento NO son entidades en INSIDEht → strings de dirección.
   provincia?: string;
-  codDepartamento?: number;
   departamento?: string;
-  codLocalidad?: number;
-  localidad?: string;
+  // La localidad SÍ es entidad (ILocalidad) → se referencia, no se duplica como
+  // string. La ingesta resuelve el nombre externo → ILocalidad (find-or-create
+  // por nombre dentro del cliente). Ver virtual `localidad`.
+  idLocalidad?: string;
   // Identidad externa (idempotencia de la ingesta)
   codigoExternoInmueble?: string; // inm_id del sistema externo
-  // Bag para el resto de campos externos no modelados (fidelidad sin bloat)
+  // Bag para campos externos no modelados: fidelidad sin bloat. Incluye los
+  // códigos del sistema externo (cod_localidad, cod_provincia, cod_departamento,
+  // etc.), que son identificadores del otro sistema, no semántica de INSIDEht.
   datosExternos?: Record<string, any>;
   // Estado
   estado?: "Activa" | "Baja";
@@ -45,6 +49,7 @@ export interface ICuentaCliente {
   division?: Division;
   // Virtuals
   puntosMedicion?: IPuntoMedicion[]; // las conexiones de la cuenta
+  localidad?: ILocalidad;
   unidadNegocio?: IUnidadNegocio;
   centroOperativo?: ICentroOperativo;
 }
@@ -53,6 +58,7 @@ export interface ICuentaCliente {
 type OmitirCreate =
   | "_id"
   | "puntosMedicion"
+  | "localidad"
   | "unidadNegocio"
   | "centroOperativo";
 export interface ICreateCuentaCliente
@@ -62,6 +68,7 @@ export interface ICreateCuentaCliente
 type OmitirUpdate =
   | "_id"
   | "puntosMedicion"
+  | "localidad"
   | "unidadNegocio"
   | "centroOperativo";
 export interface IUpdateCuentaCliente

--- a/src/interfaces/entidades/dispositivo.ts
+++ b/src/interfaces/entidades/dispositivo.ts
@@ -37,6 +37,8 @@ export interface IDispositivo {
   // Otra info
   firmware?: string;
   versionHardware?: string; // Versión de hardware (ej: "v1", "v3" para NUC con/sin GPIO)
+  serieTransmisor?: string; // serie del transmisor (integración externa, p. ej. TNS_NRO_SERIE)
+  codigoExternoTransmisor?: string; // TNS_ID del sistema externo (idempotencia de la ingesta)
   ubicacion?: ICoordenadas;
   // Info especifica de cada tipo de dispositivo
   config?: Record<string, any>;

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -11,6 +11,7 @@ export * from "./config-dispositivo";
 export * from "./correctora";
 export * from "./cromatografia";
 export * from "./cuenca";
+export * from "./cuenta-cliente";
 export * from "./dispositivo";
 export * from "./envio-sms";
 export * from "./grupo";

--- a/src/interfaces/entidades/medidor-residencial-agua.ts
+++ b/src/interfaces/entidades/medidor-residencial-agua.ts
@@ -46,10 +46,10 @@ export interface IMedidorResidencialAgua {
   diametro?: number;
   caudalMaximo?: number;
   claseMetrologica?: string;
-  // Ventana de asignación vigente medidor↔dispositivo (modelo temporal mínimo
-  // viable): el vínculo de facto es `deveui`; estas fechas acotan la ventana.
+  // Inicio de la asignación vigente medidor↔dispositivo (puntero abierto; el
+  // vínculo de facto es `deveui`). Sin fecha de fin: la atribución histórica de
+  // cada lectura la da el reporte (device.deveui + idsAsignados, inmutable).
   fechaAsignacionDispositivo?: string | null;
-  fechaFinAsignacionDispositivo?: string | null;
   //
   idCliente?: string;
   idUnidadNegocio?: string;

--- a/src/interfaces/entidades/medidor-residencial-agua.ts
+++ b/src/interfaces/entidades/medidor-residencial-agua.ts
@@ -37,6 +37,19 @@ export interface IMedidorResidencialAgua {
   titular?: ITitularMedidorResidencialAgua;
   corregido?: boolean;
   modelo?: string; /// Accell, Actaris, Itron, Gallus, Elster + lo que escriba el usuario.
+  // Metadatos / identidad externa (integración de facturación, p. ej. Manantial).
+  // La UK externa del medidor es serie+letra; `deviceMeterNumber` es numérico, por
+  // eso `serieAlfa` aloja la serie alfanumérica cuando corresponde.
+  letra?: string; // MED_LETRA (parte de la UK externa serie+letra)
+  serieAlfa?: string; // serie alfanumérica externa (si difiere de deviceMeterNumber)
+  medIdExterno?: string; // MED_ID del sistema externo (idempotencia)
+  diametro?: number;
+  caudalMaximo?: number;
+  claseMetrologica?: string;
+  // Ventana de asignación vigente medidor↔dispositivo (modelo temporal mínimo
+  // viable): el vínculo de facto es `deveui`; estas fechas acotan la ventana.
+  fechaAsignacionDispositivo?: string | null;
+  fechaFinAsignacionDispositivo?: string | null;
   //
   idCliente?: string;
   idUnidadNegocio?: string;

--- a/src/interfaces/entidades/punto-medicion.ts
+++ b/src/interfaces/entidades/punto-medicion.ts
@@ -51,7 +51,9 @@ export interface IPuntoMedicion {
   diametroConexion?: number;
   materialConexion?: string;
   facturable?: boolean;
-  ruta?: string; // agrupación "ruta" del sistema externo
+  // La "ruta" del sistema externo (nivel conexión) se modela como IAgrupacion y
+  // se vincula vía `idsAgrupaciones` (más abajo); la ingesta hace find-or-create
+  // de la agrupación por nombre. No se guarda como string suelto.
   // Dispositivo externo NUC
   idsDipositivosExternosNuc?: string[] | null;
   fechaAsignacionDispositivoExternoNuc?: string | null;

--- a/src/interfaces/entidades/punto-medicion.ts
+++ b/src/interfaces/entidades/punto-medicion.ts
@@ -14,6 +14,7 @@ import { IMedidorResidencialAgua } from "./medidor-residencial-agua";
 import { IMedidorElectrico } from "./medidor-electrico";
 import { IScada } from "./scada";
 import { ICuenca } from "./cuenca";
+import { ICuentaCliente } from "./cuenta-cliente";
 import { IDispositivoEUW300 } from "./configs-dispositivo";
 import { IDispositivoExternoNuc } from "./dispositivo-externo-nuc";
 
@@ -41,6 +42,16 @@ export interface IPuntoMedicion {
   descripcion?: string;
   codigoSimec?: string; // Para exportacion de datos a Simec
   numeroSuministro?: string; // Identificador Numero de Suministro para facturacion
+  // Cuenta / agrupador de facturación (integración externa, p. ej. Manantial).
+  // Opcional: solo lo usan clientes con la integración activa. El PM equivale a
+  // una "conexión"; la cuenta agrupa varias conexiones (ver ICuentaCliente).
+  idCuenta?: string | null;
+  codigoExternoConexion?: string; // con_id del sistema externo
+  codigoExternoInmueble?: string; // inm_id (parte de la PK compuesta externa)
+  diametroConexion?: number;
+  materialConexion?: string;
+  facturable?: boolean;
+  ruta?: string; // agrupación "ruta" del sistema externo
   // Dispositivo externo NUC
   idsDipositivosExternosNuc?: string[] | null;
   fechaAsignacionDispositivoExternoNuc?: string | null;
@@ -57,6 +68,9 @@ export interface IPuntoMedicion {
   // Medidor Residencial Agua
   idMedidorResidencialAgua?: string | null;
   fechaAsignacionMedidorResidencialAgua?: string | null;
+  // Cierre de ventana de asignación vigente (modelo temporal mínimo viable):
+  // al reasignar/desasignar, se setea el fin antes de pisar el puntero.
+  fechaFinAsignacionMedidorResidencialAgua?: string | null;
   // Medidor Electrico
   idMedidorElectrico?: string | null;
   fechaAsignacionMedidorElectrico?: string | null;
@@ -107,6 +121,7 @@ export interface IPuntoMedicion {
   grupos?: IGrupo[];
   agrupaciones?: IAgrupacion[];
   cuenca?: ICuenca;
+  cuenta?: ICuentaCliente;
 }
 
 ////// CREATE/UPDATE
@@ -125,7 +140,8 @@ type Omitir =
   | "subzonaTarifaria"
   | "grupos"
   | "agrupaciones"
-  | "cuenca";
+  | "cuenca"
+  | "cuenta";
 export interface ICreatePuntoMedicion extends Omit<
   Partial<IPuntoMedicion>,
   Omitir

--- a/src/interfaces/entidades/punto-medicion.ts
+++ b/src/interfaces/entidades/punto-medicion.ts
@@ -70,9 +70,6 @@ export interface IPuntoMedicion {
   // Medidor Residencial Agua
   idMedidorResidencialAgua?: string | null;
   fechaAsignacionMedidorResidencialAgua?: string | null;
-  // Cierre de ventana de asignación vigente (modelo temporal mínimo viable):
-  // al reasignar/desasignar, se setea el fin antes de pisar el puntero.
-  fechaFinAsignacionMedidorResidencialAgua?: string | null;
   // Medidor Electrico
   idMedidorElectrico?: string | null;
   fechaAsignacionMedidorElectrico?: string | null;

--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -218,6 +218,16 @@ export interface IConfigCliente {
    * actualizar punto. Chequear con `!== false` para preservar el default.
    */
   crearMedidorResidencialAutomatico?: boolean;
+
+  /**
+   * Habilita la UI de Cuentas (agrupador de facturación, ver ICuentaCliente) en
+   * los frontends. Capability de solo-visualización: la lógica de backend es
+   * transparente (campos nullable) y la ingesta se activa por presencia de
+   * config en `integraciones`. El backend AUTO-SETEA este flag al configurar una
+   * integración que puebla cuentas (p. ej. Manantial); no hay toggle en admin.
+   * Default undefined/false: el cliente no ve nada de cuentas.
+   */
+  gestionCuentas?: boolean;
 }
 
 export interface ICliente {

--- a/src/interfaces/tenant/integraciones.ts
+++ b/src/interfaces/tenant/integraciones.ts
@@ -7,6 +7,15 @@ export interface IIntegracion {
   credenciales?: IIntegracionInfluxV1 | IIntegracionInfluxV2;
   credenciales2?: { key: string; value: string }[];
   ubicacionCredenciales?: "Query Params" | "Headers" | "Body";
+  // Integración de altas/asociaciones + devolución de lecturas (p. ej. Manantial
+  // de AYSAM). Las integraciones históricas modelan push OUTBOUND; estos campos
+  // agregan la ingesta pull INBOUND y el perfil del adaptador.
+  direccion?: "INBOUND_PULL" | "OUTBOUND_API";
+  perfil?: "MANANTIAL"; // adaptador/mapper específico del sistema externo
+  endpointIngesta?: string; // base del GET de altas (p. ej. .../mediciones/v1)
+  // Watermark de la ingesta incremental (idempotencia / "solo lo nuevo").
+  cursorAltas?: string;
+  ultimaSincronizacion?: string;
 }
 
 export interface IIntegracionInfluxV1 {


### PR DESCRIPTION
## Fase 1 — Modelo de datos

Primera fase del plan de integración INSIDEht ↔ sistemas de facturación externos (objetivo **AYSAM / Sistema Manantial**, device **ML107A** residencial agua). Ver `PLAN-INTEGRACION-AYSAM.md`.

**Principio:** todo **aditivo y nullable** → los clientes sin la integración siguen funcionando exactamente igual. Sin cambios de comportamiento, solo interfaces nuevas/opcionales.

### Cambios
- **`ICuentaCliente`** (nueva entidad `cuenta-cliente.ts`): agrupador de facturación, análogo al inmueble/cuenta de Manantial, que agrupa N puntos de medición ("conexiones"). No existía equivalente en INSIDEht.
  - Referencia `idLocalidad` (entidad `ILocalidad`), **no** string — se resuelve en la ingesta (find-or-create por nombre). Provincia/departamento quedan como strings (sin entidad). Códigos externos (`cod_*`) → bag `datosExternos`.
- **`IPuntoMedicion`**: `idCuenta` + virtual `cuenta` (FK plano estructural, sin fecha — fiel a Manantial, donde conexión↔inmueble es identidad, no junction temporal); metadatos de conexión (`codigoExternoConexion`/`codigoExternoInmueble`/`diametroConexion`/`materialConexion`/`facturable`). La **ruta** se modela como `IAgrupacion` vía el `idsAgrupaciones` existente (no string suelto).
- **`IMedidorResidencialAgua`**: `letra`, `serieAlfa`, `medIdExterno`, `diametro`, `caudalMaximo`, `claseMetrologica`; `fechaAsignacionDispositivo` (inicio del vínculo medidor↔dispositivo vigente).
- **`IDispositivo`**: `serieTransmisor`, `codigoExternoTransmisor`.
- **`IIntegracion`**: `direccion` (INBOUND_PULL/OUTBOUND_API), `perfil` (MANANTIAL), `endpointIngesta`, `cursorAltas`, `ultimaSincronizacion`.
- **`IConfigCliente`**: `gestionCuentas` (capability de UI, auto-seteado por backend al configurar la integración; sin toggle en admin).

### Decisiones de diseño
- **Cuenta** = entidad nueva (no campo lógico): `account`/`metervalues` operan por cuenta y necesitan alojar régimen/coords/etc.
- **No duplicar entidades**: lo que tiene entidad en INSIDEht se referencia (localidad → `ILocalidad`, ruta → `IAgrupacion`), no se guarda como string. Resolución en la ingesta.
- **Asignaciones = puntero vigente simple, sin `fechaFin`**. Manantial guarda historial en junctions RCM/RTM (ventana inicio/fin + auditoría + N filas). No se replica: la atribución histórica por-lectura ya vive **inmutable** en cada `IReporte` (`idsAsignados` + `device.deveui` al escribir). `account` usa el puntero; `metervalues` usa los reportes.
- **Atribución de lecturas por cuenta (A1)**: el write-path estampará `idCuenta` en `idsAsignados` del reporte → query de `metervalues` por cuenta reusa el índice existente + atribución inmutable (fase posterior en gas-datos/gas-api-ml107a).

### Notas
- gas-modelos es interfaces-only (sin build). Imports verificados contra los barrels (mismo patrón que `subzona-tarifaria`).
- Al mergear: publicar y **re-pinnear lockfiles** en los consumidores antes de la Fase 2 (gas-datos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)