### PR TITLE
feat(sml): agregar código de unidad de caudal a IReporteSML

### DIFF
--- a/src/interfaces/entidades/valores-reporte/sml.ts
+++ b/src/interfaces/entidades/valores-reporte/sml.ts
@@ -10,6 +10,12 @@ export interface IReporteSML {
   reverse_accumulated_flow?: number;
   batteryVoltage?: number;
   statusWord?: number;
+  // Código de unidad de caudal del medidor (byte de unidad de la trama, familia
+  // ML107A Reallin/HolleyBeta). Determina el factor de escala del flujo acumulado
+  // a m³. Enum del fabricante: 0x29 L (÷1000), 0x2A L×10 (÷100), 0x2B L×100 (÷10),
+  // 0x2C m³ (×1), 0x2D m³×10 (×10), 0x2E m³×100 (×100). Se persiste el código crudo
+  // para trazabilidad; el consumo ya viene escalado con el factor correspondiente.
+  unidad?: number;
   triggerSource?: number;
   checksum?: number;
   // Parsed


### PR DESCRIPTION
## Contexto

Ingeniería inversa del payload del medidor de agua **ML107A** (Reallin/HolleyBeta) confirmó, con citas del código decompilado del fabricante y validación contra tramas productivas reales, que la trama trae un **byte de unidad de caudal** (offset 15 en la trama larga) que determina el factor de escala del flujo acumulado a m³:

| hex | etiqueta | factor a m³ |
|-----|----------|-------------|
| 0x29 | L | ÷1000 |
| 0x2A | L×10 | ÷100 |
| 0x2B | L×100 | ÷10 |
| 0x2C | m³ | ×1 |
| 0x2D | m³×10 | ×10 |
| 0x2E | m³×100 | ×100 |

Hoy `gas-api-ml107a` aplica un `/100` hardcodeado que solo funciona porque los devices de campo reportan `0x2A` (L×10). Otro device podría reportar otra unidad.

## Cambio

Agrega `unidad?: number` a `IReporteSML` para persistir el **código crudo** de unidad reportado por el dispositivo, dando trazabilidad al factor aplicado. El `consumo` ya se persiste escalado; este campo guarda el código de origen.

Habilita el fix del parser en `gas-api-ml107a` (deriva el factor del byte de unidad en vez de hardcodear `/100`) y la normalización a m³ para la integración AYSAM.

Repo de solo-interfaces, sin build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)