### PR TITLE
feat: tipo de dispositivo OCR + IReporteOCR ("SML óptico")

### DIFF
--- a/src/interfaces/auxiliares/tipoDispositivo.ts
+++ b/src/interfaces/auxiliares/tipoDispositivo.ts
@@ -48,7 +48,8 @@ export type TipoDispositivoGas =
   | "EUW300"
   | "BOVE"
   | "ML107GH"
-  | "NME";
+  | "NME"
+  | "OCR";
 
 export const TIPOS_DISPOSITIVOS: TipoDispositivoGas[] = [
   "NUC",
@@ -64,4 +65,5 @@ export const TIPOS_DISPOSITIVOS: TipoDispositivoGas[] = [
   "BOVE",
   "ML107GH",
   "NME",
+  "OCR",
 ];

--- a/src/interfaces/entidades/valores-reporte/index.ts
+++ b/src/interfaces/entidades/valores-reporte/index.ts
@@ -7,5 +7,6 @@ export * from "./wrc";
 export * from "./scada";
 export * from "./euw300";
 export * from "./bove";
+export * from "./ocr";
 export * from "./reporte-medidor-agual";
 export * from "./reporte-inputs-nuc";

--- a/src/interfaces/entidades/valores-reporte/ocr.ts
+++ b/src/interfaces/entidades/valores-reporte/ocr.ts
@@ -18,6 +18,12 @@ export interface IReporteOCR {
   lectura?: number;
   consumo?: number; // Acumulado reportado (= lectura del odómetro).
   consumoCorregido?: number; // Acumulado +- consumoInicial cargado en la plataforma.
+  // Consumo parcial desde el último reporte (consumoCorregido de este reporte -
+  // consumoCorregido del último reporte del medidor). A diferencia de SML/WRC —que
+  // reportan consumoInstantaneo desde el propio device—, el dispositivo OCR solo
+  // entrega la lectura acumulada del odómetro, así que el parcial se CALCULA en el
+  // backend. Misma convención que consumoParcialInputN (NUC) y flujo*Parcial (agua).
+  consumoParcial?: number;
 
   // Fuente 1: lectura del propio dispositivo (OCR on-device).
   ocrReadingDevice?: number;

--- a/src/interfaces/entidades/valores-reporte/ocr.ts
+++ b/src/interfaces/entidades/valores-reporte/ocr.ts
@@ -1,0 +1,55 @@
+// Valores de reporte del dispositivo OCR ("SML óptico"): cámara 4G/LTE montada
+// sobre el odómetro mecánico de un medidor residencial de gas SIN salida de
+// pulsos. El dispositivo fotografía el visor y hace OCR on-device; el backend
+// (gas-ocr-worker, RapidOCR/ONNX + Tesseract) corre un OCR de verificación
+// independiente y llena los campos `confianzaBackend`/`fuentesAcuerdo`/`estadoOcr`.
+// La lectura de facturación se promueve a `auto` solo con consenso + sanidad;
+// de lo contrario cae a la cola de revisión humana (`revision`).
+//
+// Bag plano de campos opcionales, convención del sistema (ver IReporteSML). Los
+// campos `imageRef` + `estadoOcr` + `confianzaBackend` lo discriminan de otras
+// variantes de IValoresReporte sin ambigüedad.
+export interface IReporteOCR {
+  // ISO 8601 (nunca Date).
+  timestamp?: string;
+
+  // Lectura final del odómetro en m³ (entero.decimal). Familia `consumo` alineada
+  // con IReporteSML/IReporteWRC para reusar el render residencial existente.
+  lectura?: number;
+  consumo?: number; // Acumulado reportado (= lectura del odómetro).
+  consumoCorregido?: number; // Acumulado +- consumoInicial cargado en la plataforma.
+
+  // Fuente 1: lectura del propio dispositivo (OCR on-device).
+  ocrReadingDevice?: number;
+  ocrConfidenceDevice?: number;
+
+  // Fuente 2/3: OCR de verificación del backend.
+  confianzaBackend?: number; // 0–1 (fracción). Documentado: fracción, no porcentaje.
+  confianzasPorCelda?: number[]; // Confianza por dígito del odómetro.
+
+  // Flags de consenso entre las fuentes (auditoría del gate auto/revision).
+  fuentesAcuerdo?: {
+    device: boolean;
+    rapidocr: boolean;
+    tesseract: boolean;
+  };
+
+  // Máquina de estados de la lectura:
+  // pendiente  -> creada por la ingesta, aún sin OCR backend
+  // revision   -> baja confianza / divergencia -> cola de revisión humana
+  // auto       -> consenso + sanidad -> auto-aceptada
+  // confirmado -> operador validó la lectura auto/manual
+  // corregido  -> operador sobreescribió la lectura
+  estadoOcr?: "pendiente" | "revision" | "auto" | "confirmado" | "corregido";
+
+  // Key del objeto GCS de la imagen upright (fuente de verdad para auditoría,
+  // retención >= 1 año). NO base64 ni URL pública: el frontend obtiene una
+  // signed URL v4 de vida corta a partir de este key.
+  imageRef?: string;
+
+  // Unidad enviada por el dispositivo (p. ej. "m3").
+  meterUnit?: string;
+
+  // Nivel de batería (%). Convención `bateria` de las familias de medidor.
+  bateria?: number;
+}

--- a/src/interfaces/entidades/valores-reporte/ocr.ts
+++ b/src/interfaces/entidades/valores-reporte/ocr.ts
@@ -24,6 +24,12 @@ export interface IReporteOCR {
   // entrega la lectura acumulada del odómetro, así que el parcial se CALCULA en el
   // backend. Misma convención que consumoParcialInputN (NUC) y flujo*Parcial (agua).
   consumoParcial?: number;
+  // Tiempo transcurrido desde el último reporte, en segundos (timestamp de este
+  // reporte - timestamp del último reporte del medidor). Contextualiza el parcial:
+  // permite derivar una tasa de consumo (consumoParcial / intervalo) y validar la
+  // cadencia. Se calcula en el backend junto con consumoParcial. En segundos (no
+  // intervaloHoras como EUW300/BOVE) porque la cadencia del OCR es variable.
+  intervaloReporteSegundos?: number;
 
   // Fuente 1: lectura del propio dispositivo (OCR on-device).
   ocrReadingDevice?: number;

--- a/src/interfaces/entidades/valores-reporte/valoresReporte.ts
+++ b/src/interfaces/entidades/valores-reporte/valoresReporte.ts
@@ -7,6 +7,7 @@ import { IReporteSML } from "./sml";
 import { IReporteVeribox } from "./veribox";
 import { IReporteWRC } from "./wrc";
 import { IReporteInputsNuc } from "./reporte-inputs-nuc";
+import { IReporteOCR } from "./ocr";
 
 export type IValoresReporte =
   | IReporteNUC
@@ -19,4 +20,5 @@ export type IValoresReporte =
   | IReporteHorarioEUW300
   | IReporteTotalizadorBove
   | IReporteLogsHorariosBove
-  | IReporteInputsNuc;
+  | IReporteInputsNuc
+  | IReporteOCR;


### PR DESCRIPTION
## Qué

Fase **B1** del plan OCR cámara (`PLAN-OCR-CAMERA-IMPLEMENTACION.md`): agrega el nuevo tipo de dispositivo **OCR** y su bag de valores de reporte `IReporteOCR`.

El dispositivo OCR ("SML óptico") es una cámara 4G/LTE montada sobre el odómetro mecánico de medidores residenciales de gas **sin salida de pulsos**. Fotografía el visor + hace OCR on-device; el backend corre un OCR de verificación independiente.

## Cambios

- `auxiliares/tipoDispositivo.ts`: `"OCR"` en `TipoDispositivoGas` y `TIPOS_DISPOSITIVOS`.
- `entidades/valores-reporte/ocr.ts` (**nuevo**): `IReporteOCR` — `lectura` m³, `ocrReadingDevice`/`ocrConfidenceDevice`, `confianzaBackend` (0–1), `confianzasPorCelda`, `fuentesAcuerdo`, `estadoOcr` (`pendiente|revision|auto|confirmado|corregido`), `imageRef` (key GCS imagen upright, retención ≥ 1 año), `meterUnit`, `bateria`.
- `entidades/valores-reporte/valoresReporte.ts`: `IReporteOCR` en la unión `IValoresReporte`.
- `entidades/valores-reporte/index.ts`: re-export en el barrel.

## Decisiones

- Reusa `IMedidorResidencial` existente (ruta GAS, division `Residencial`) — sin entidad nueva.
- `confianzaBackend` = fracción 0–1.
- Sin `rssi`/`snr` en el reporte (viven en `IDispositivo`).
- `imageRef` guarda el **key GCS**, no base64 ni URL pública (frontend usa signed URL v4).

## Notas

Repo interfaces-only (sin build step). **Bloquea**: A2 (gas-api-ocr), A3 (worker), B2–B5. Tras merge → `npm run modelos` en consumidores (gas-datos, gas-api-cliente, gas-api-ocr, gas-web-cliente) para pinnear el commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)