### PR TITLE
feat(uwm-nb): tipos del medidor de agua NB-IoT UWM-NB

### DIFF
--- a/src/interfaces/auxiliares/tipoDispositivo.ts
+++ b/src/interfaces/auxiliares/tipoDispositivo.ts
@@ -49,7 +49,8 @@ export type TipoDispositivoGas =
   | "BOVE"
   | "ML107GH"
   | "NME"
-  | "OCR";
+  | "OCR"
+  | "UWM-NB";
 
 export const TIPOS_DISPOSITIVOS: TipoDispositivoGas[] = [
   "NUC",
@@ -66,4 +67,5 @@ export const TIPOS_DISPOSITIVOS: TipoDispositivoGas[] = [
   "ML107GH",
   "NME",
   "OCR",
+  "UWM-NB",
 ];

--- a/src/interfaces/entidades/configs-dispositivo/dispositivoUwmNb.ts
+++ b/src/interfaces/entidades/configs-dispositivo/dispositivoUwmNb.ts
@@ -1,0 +1,45 @@
+/**
+ * Configuración específica del medidor de agua ultrasónico NB-IoT "UWM-NB".
+ *
+ * Device de la licitación OSE Evoluciona (UY). Transporte: UDP crudo (NB-IoT/LTE-M),
+ * 1 tx/día, buffer 72 h. Identidad = `meterId` (dentro del frame; no hay api-key).
+ * Fase 1 = payload plano; fase 2 = payload cifrado AES-128 (clave por device).
+ *
+ * Fabricante aún no seleccionado (nombre de tipo genérico a propósito). Campos de
+ * comunicación tomados del patrón IDispositivoSml (ip/port) + IDispositivoNme (versionFw).
+ */
+
+import { IReporteUWMNB } from "../valores-reporte";
+
+export interface IDispositivoUwmNb {
+  // --- Identidad ---
+  meterId?: string; // METER_ID, 12 díg (equiv. deviceMeterNumber; string, no number)
+  deviceMeterNumber?: string; // alias/compatibilidad con el resto de medidores de agua
+  imsi?: string; // IMSI de la SIM (15 díg; string para no perder ceros)
+  iccid?: string; // ICCID de la SIM (opcional; string, 19-20 díg)
+
+  // --- Comunicación NB-IoT/LTE-M ---
+  ip?: string; // IP del device (Local_IP reportada)
+  puerto?: number; // puerto UDP al que reporta (plano vs AES)
+  operadora?: string; // operadora móvil (Antel, etc.)
+  versionFw?: number | string; // versión de firmware (BCD en el frame)
+
+  // --- Cifrado (fase 2; ver plan §4) ---
+  modoTransmision?: "plano" | "aes-128"; // seleccionado por puerto
+  claveAes?: string; // clave AES-128 por device (16 B, hex 32 chars). Secreto en reposo.
+
+  // --- Configuración de reporte ---
+  intervaloComunicacion?: number; // minutos/horas entre reportes (informativo; 1 tx/día)
+  horaReporteDiario?: string; // hora del reporte diario (HH:mm), si se conoce
+
+  // --- Último reporte / estado ---
+  ultimoReporte?: IReporteUWMNB;
+  estadoGeneral?: "normal" | "alerta" | "error";
+
+  // --- Flags de alerta (paridad con EUW300) ---
+  alertaBateriaActivada?: boolean;
+  alertaFlujoInversoActivada?: boolean;
+  alertaSobreflujoActivada?: boolean;
+  alertaGoteoActivada?: boolean;
+  alertaTuboVacioActivada?: boolean;
+}

--- a/src/interfaces/entidades/configs-dispositivo/index.ts
+++ b/src/interfaces/entidades/configs-dispositivo/index.ts
@@ -5,3 +5,4 @@ export * from "./dispositivoNuc4G";
 export * from "./dispositivoVeriboxMicro";
 export * from "./dispositivoSml";
 export * from "./dispositivoNme";
+export * from "./dispositivoUwmNb";

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -29,6 +29,7 @@ export * from "./medidor-electrico";
 export * from "./punto-medicion";
 export * from "./registro";
 export * from "./registro-medidor-electrico";
+export * from "./registro-horario-agua";
 export * from "./reporte";
 export * from "./unidad-presion";
 export * from "./firmware";

--- a/src/interfaces/entidades/registro-horario-agua.ts
+++ b/src/interfaces/entidades/registro-horario-agua.ts
@@ -1,0 +1,98 @@
+import { ICliente } from '../tenant';
+import { ICentroOperativo } from '../gas/centroOperativo';
+import { IUnidadNegocio } from '../gas/unidadNegocio';
+import { IPuntoMedicion } from './punto-medicion';
+import { ILocalidad } from './localidad';
+import { IGrupo } from './grupo';
+import { ICuenca } from './cuenca';
+import { IAgrupacion } from '../gas';
+import { IMedidorResidencialAgua } from './medidor-residencial-agua';
+
+/**
+ * Registro horario de un medidor de agua residencial (serie temporal).
+ *
+ * Motivación (device UWM-NB, ver gas/PLAN-UWM-NB-INTEGRACION.md §3.2): el frame diario
+ * trae un buffer de hasta 72 volúmenes horarios y llega 1 vez/día, pero el buffer cubre
+ * las últimas 72 h → cada hora reaparece en ~3 frames consecutivos. Persistir la serie
+ * en una colección aparte con UPSERT idempotente por (deveui, timestamp) deduplica el
+ * solapamiento y hace la ingesta re-inyectable desde el DLQ sin duplicar registros.
+ * Espejo del patrón de IRegistroMedidorElectrico (NME).
+ *
+ * El volumen es un odómetro TOTAL (m³); `consumoParcial` es el delta consumido en esa
+ * hora respecto del registro previo (lo calcula el backend, patrón SML/NME).
+ *
+ * NOTA (zona horaria): `timestamp` se ancla con el supuesto de RTC en hora local UY
+ * (UTC-3), no UTC. Ver R1 del plan.
+ *
+ * Colección genérica de agua (no atada a UWM-NB): cualquier device de agua residencial
+ * con buffer horario puede escribir acá; el vínculo es por `deveui` + `idMedidorResidencialAgua`.
+ */
+export interface IRegistroHorarioAgua {
+  _id?: string;
+  timestamp?: string; // ISO, hora en punto (cierre de la hora)
+  //
+  volumenM3?: number; // odómetro TOTAL de esa hora (m³)
+  consumoParcial?: number; // delta respecto del registro previo (m³)
+  //
+  deveui?: string;
+  deviceName?: string;
+  meterId?: string;
+  //
+  idMedidorResidencialAgua?: string;
+  idPuntoMedicion?: string;
+  //
+  idCliente?: string;
+  idUnidadNegocio?: string;
+  idCentroOperativo?: string;
+  idLocalidad?: string;
+  idCuenca?: string;
+  idsGrupos?: string[];
+  idsAgrupaciones?: string[];
+  //
+  fechaCreacion?: string;
+
+  // Virtuals
+  cliente?: ICliente;
+  unidadNegocio?: IUnidadNegocio;
+  centroOperativo?: ICentroOperativo;
+  localidad?: ILocalidad;
+  cuenca?: ICuenca;
+  puntoMedicion?: IPuntoMedicion;
+  medidorResidencialAgua?: IMedidorResidencialAgua;
+  grupos?: IGrupo[];
+  agrupaciones?: IAgrupacion[];
+}
+
+////// CREATE
+type OmitirCreate =
+  | '_id'
+  | 'cliente'
+  | 'unidadNegocio'
+  | 'centroOperativo'
+  | 'localidad'
+  | 'cuenca'
+  | 'puntoMedicion'
+  | 'medidorResidencialAgua'
+  | 'grupos'
+  | 'agrupaciones';
+export interface ICreateRegistroHorarioAgua extends Omit<
+  Partial<IRegistroHorarioAgua>,
+  OmitirCreate
+> {}
+
+////// UPDATE
+type OmitirUpdate =
+  | '_id'
+  | 'cliente'
+  | 'unidadNegocio'
+  | 'centroOperativo'
+  | 'localidad'
+  | 'cuenca'
+  | 'puntoMedicion'
+  | 'medidorResidencialAgua'
+  | 'grupos'
+  | 'agrupaciones';
+export interface IUpdateRegistroHorarioAgua extends Omit<
+  Partial<IRegistroHorarioAgua>,
+  OmitirUpdate
+> {}

--- a/src/interfaces/entidades/valores-reporte/index.ts
+++ b/src/interfaces/entidades/valores-reporte/index.ts
@@ -8,5 +8,6 @@ export * from "./scada";
 export * from "./euw300";
 export * from "./bove";
 export * from "./ocr";
+export * from "./uwm-nb";
 export * from "./reporte-medidor-agual";
 export * from "./reporte-inputs-nuc";

--- a/src/interfaces/entidades/valores-reporte/uwm-nb.ts
+++ b/src/interfaces/entidades/valores-reporte/uwm-nb.ts
@@ -1,0 +1,65 @@
+/**
+ * Valores de reporte del medidor de agua ultrasónico NB-IoT "UWM-NB".
+ *
+ * Origen: medidor NB-IoT/LTE-M de la licitación OSE Evoluciona (UY, Lic. 26973).
+ * El equipo transmite 1 frame binario/día (trama 374 B estilo DL/T-645, big-endian,
+ * campos ASCII/HEX/BCD) por UDP crudo. Spec de payload validada byte a byte contra
+ * trama real. Detalle en gas/PLAN-UWM-NB-INTEGRACION.md §3.
+ *
+ * NOTA (zona horaria): por ahora se asume que el RTC del device reporta en HORA LOCAL
+ * (UY, UTC-3), no UTC. Los `timestamp` ISO se construyen con ese supuesto en el decoder
+ * (gas-api-uwm-nb). Confirmar con el proveedor; ver R1 del plan.
+ *
+ * Volumen = odómetro TOTAL (siempre creciente), en m³ (BCD 8 díg / 1000). También las
+ * lecturas horarias son volumen total, no incremento (pese al label "increment" del
+ * fabricante); el delta por hora lo calcula el backend (`consumoParcial`).
+ */
+
+import { ITipoAlerta } from "../alerta";
+
+/** Lectura puntual (realtime o congelada diaria) — 11 B BCD del frame. */
+export interface ILecturaUWMNB {
+  timestamp: string; // ISO — RTC del device (Year/Month/Day/Hour/Minute BCD)
+  volumenM3: number; // odómetro TOTAL, m³ (BCD 8 díg / 1000)
+  alarmas: ITipoAlerta[]; // mapeadas desde el bitmask de 8 bits (ver plan §3.3)
+  alarmBitsRaw?: number; // BYTE2 crudo del campo Alarm (BYTE1 REVERSE se ignora)
+}
+
+/** Muestra horaria del buffer (72 registros) — volumen TOTAL, no incremento. */
+export interface ILecturaHorariaUWMNB {
+  timestamp: string; // ISO, anclado a la hora en punto
+  volumenM3: number; // odómetro TOTAL, m³
+  consumoParcial?: number; // delta vs. hora previa (lo calcula el backend)
+}
+
+export interface IReporteUWMNB {
+  // --- Identidad / radio (crudos del frame) ---
+  meterId: string; // METER_ID, 12 díg ASCII
+  ip?: string; // Local_IP del device
+  imsi?: string; // IMSI de la SIM
+  ciclosTx?: number; // CYCLES_TX (transmisiones totales)
+  ciclosTxBad?: number; // CYCLES_TX_BAD (transmisiones fallidas)
+  rssi?: number; // RSSI_SNR[0] (unidad sin confirmar; ver R4 del plan)
+  snr?: number; // RSSI_SNR[1]
+  valveStatusRaw?: number; // VALVE_STATUS (reservado; se persiste crudo)
+
+  // --- Batería / firmware ---
+  vbatMedicionMv?: number; // uint16 mV (batería de medición)
+  vbatComunicacionMv?: number; // uint16 mV (batería de comunicación)
+  bateria?: number; // % estimado desde vbatMedicion
+  fwVersion?: number; // BCD (el CRC de programa se descarta)
+
+  // --- Lecturas ---
+  lecturaTiempoReal?: ILecturaUWMNB; // REALTIME_DATA
+  lecturaCongeladaDiaria?: ILecturaUWMNB; // FROZEN_DATA_DAILY
+  lecturasHorarias?: ILecturaHorariaUWMNB[]; // 0..72 (usar LENGTH, no asumir 72)
+
+  // --- Convención común de reportes (espejo WRC/SML) ---
+  timestamp?: string; // = lecturaTiempoReal.timestamp; lo usa el write-path
+  consumo?: number; // = lecturaTiempoReal.volumenM3 (odómetro total)
+  consumoCorregido?: number; // consumo ± offset (consumoInicial cargado en plataforma)
+  consumoParcial?: number; // consumo - consumo del último reporte
+
+  frameLen?: number; // LENGTH declarado en la trama (detecta frames degradados)
+  crcOk?: boolean; // resultado de la validación de checksum (suma mod 256)
+}

--- a/src/interfaces/entidades/valores-reporte/valoresReporte.ts
+++ b/src/interfaces/entidades/valores-reporte/valoresReporte.ts
@@ -8,6 +8,7 @@ import { IReporteVeribox } from "./veribox";
 import { IReporteWRC } from "./wrc";
 import { IReporteInputsNuc } from "./reporte-inputs-nuc";
 import { IReporteOCR } from "./ocr";
+import { IReporteUWMNB } from "./uwm-nb";
 
 export type IValoresReporte =
   | IReporteNUC
@@ -21,4 +22,5 @@ export type IValoresReporte =
   | IReporteTotalizadorBove
   | IReporteLogsHorariosBove
   | IReporteInputsNuc
-  | IReporteOCR;
+  | IReporteOCR
+  | IReporteUWMNB;


### PR DESCRIPTION
## Contexto

Primer paso (Fase A) de la integración del medidor de agua ultrasónico **NB-IoT** de la licitación **OSE Evoluciona** (UY, Lic. 26973) a INSIDEht como device de **agua residencial** nuevo, tipo `UWM-NB`.

Plan completo end-to-end: `gas/PLAN-UWM-NB-INTEGRACION.md`. Patrón: transporte estilo `gas-api-wrc` (UDP crudo NB-IoT) + negocio estilo `gas-api-euw300` (agua residencial). Reúso total de la división **"Residencial Agua"** e `IMedidorResidencialAgua`.

## Cambios (solo tipos — este paquete no compila)

- **`tipoDispositivo.ts`**: `"UWM-NB"` agregado a `TipoDispositivoGas` y `TIPOS_DISPOSITIVOS`.
- **`valores-reporte/uwm-nb.ts`** (nuevo): `IReporteUWMNB` + `ILecturaUWMNB` + `ILecturaHorariaUWMNB`. Volumen = odómetro **total** en m³, alarmas mapeadas a `ITipoAlerta` existentes, doble batería (medición/comunicación), rssi/snr, buffer de 72 horarias. Sumado a la unión `IValoresReporte`.
- **`configs-dispositivo/dispositivoUwmNb.ts`** (nuevo): `IDispositivoUwmNb` (meterId, imsi, ip, puerto, versionFw + `claveAes`/`modoTransmision` para fase 2 AES-128). Strings para imsi/iccid/meterId (no number).
- **`registro-horario-agua.ts`** (nuevo): `IRegistroHorarioAgua`, colección de serie temporal (espejo de `IRegistroMedidorElectrico`). **Upsert por `(deveui, timestamp)`** para deduplicar el solapamiento de 72 h del buffer diario.

## Notas

- Payload del device **cerrado y validado byte a byte** contra trama real (trama 374 B DL/T-645, CRC suma mod256, 72 horarias).
- **Zona horaria**: se asume RTC en **hora local UY (UTC-3)**, no UTC (a confirmar con proveedor).
- Nombre `UWM-NB` genérico a propósito (fabricante del medidor aún no seleccionado).
- Desbloquea Fases B (servicio `gas-api-uwm-nb`), C (gas-datos), D (web-cliente) y E (web-admin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)