### PR TITLE
feat(clima+geo): geo en Localidad + modelo de clima (INSIDEht 2.0)

### DIFF
--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -17,6 +17,7 @@ export * from "./envio-sms";
 export * from "./grupo";
 export * from "./kmz";
 export * from "./localidad";
+export * from "./registro-clima";
 export * from "./log-nuc";
 export * from "./log-lora";
 export * from "./log-reporte";

--- a/src/interfaces/entidades/localidad.ts
+++ b/src/interfaces/entidades/localidad.ts
@@ -1,6 +1,14 @@
 import { ICliente } from "../tenant";
 import { ICentroOperativo } from "../gas/centroOperativo";
 import { IUnidadNegocio } from "../gas/unidadNegocio";
+import { ICoordenadas, GeoJSON } from "../auxiliares/coordenadas";
+
+/**
+ * Origen de la geometria de una Localidad.
+ * - "OSM": importada de OpenStreetMap (Overpass, admin boundaries) con confirmacion manual.
+ * - "Manual": dibujada/editada a mano en el frontend.
+ */
+export type OrigenGeometriaLocalidad = "OSM" | "Manual";
 
 export interface ILocalidad {
   _id?: string;
@@ -9,6 +17,17 @@ export interface ILocalidad {
   idCentroOperativo?: string;
 
   nombre?: string;
+
+  /**
+   * Geografia de la Localidad (INSIDEht 2.0). La jerarquia UN/CO NO tiene geometria
+   * propia: agregan/sectorizan hacia arriba desde las Localidades que contienen.
+   * Todos los campos son opcionales (aditivos): una Localidad sin geo se excluye de
+   * las metricas/clima por zona.
+   */
+  ubicacion?: ICoordenadas; // centroide (siempre que haya geo) — usado para consultar clima y centrar mapa
+  geojson?: GeoJSON; // poligono opcional de la zona (Polygon / MultiPolygon) — indice 2dsphere en gas-datos
+  origenGeometria?: OrigenGeometriaLocalidad;
+  osmRelationId?: number; // referencia a la relacion OSM cuando origenGeometria === "OSM"
 
   // Virtuals
   cliente?: ICliente;

--- a/src/interfaces/entidades/registro-clima.ts
+++ b/src/interfaces/entidades/registro-clima.ts
@@ -1,0 +1,92 @@
+import { ICliente } from "../tenant";
+import { ICentroOperativo } from "../gas/centroOperativo";
+import { IUnidadNegocio } from "../gas/unidadNegocio";
+import { ILocalidad } from "./localidad";
+import { ICoordenadas } from "../auxiliares/coordenadas";
+
+/**
+ * Registro climatico de una Localidad (INSIDEht 2.0).
+ *
+ * Serie temporal propia, servida por gas-api-clima y persistida en gas-datos
+ * (coleccion propia, upsert por `idLocalidad` + `timestamp` + `tipo` + `fuente`).
+ * El clima se resuelve POR LOCALIDAD (centroide); UN/CO promedian hacia arriba.
+ *
+ * Las unidades son CANONICAS (ver cada campo): gas-api-clima normaliza lo que
+ * devuelve cada proveedor a estas unidades antes de persistir. Este paquete es
+ * solo de tipos (no se compila a JS), por eso las unidades se documentan aca.
+ */
+
+/** Proveedor del dato climatico. OpenWeatherMap es el primario del MVP. */
+export type FuenteClima =
+  | "OpenWeatherMap"
+  | "Open-Meteo"
+  | "SMN"
+  | "Estacion"; // estacion meteorologica propia (futuro, fuera de alcance MVP)
+
+/**
+ * Tipo de dato climatico.
+ * - "ACTUAL": observacion/estado presente.
+ * - "PRONOSTICO": pronostico a futuro (fuente 1 — API).
+ * - "CLIMATOLOGIA": normal esperada derivada del historico de la ubicacion
+ *   (fuente 2 — "el historico de la ubicacion geografica"), por dia del año.
+ */
+export type TipoDatoClima = "ACTUAL" | "PRONOSTICO" | "CLIMATOLOGIA";
+
+export interface IViento {
+  velocidad?: number; // m/s
+  direccion?: number; // grados 0-360 (de donde viene)
+  rafaga?: number; // m/s
+}
+
+export interface IRegistroClima {
+  _id?: string;
+
+  timestamp?: string; // ISO UTC — instante del dato (o dia objetivo para PRONOSTICO/CLIMATOLOGIA)
+  tipo?: TipoDatoClima;
+  fuente?: FuenteClima;
+
+  // Variables canonicas (normalizadas por gas-api-clima)
+  temperatura?: number; // °C
+  temperaturaMin?: number; // °C — agregados diarios / pronostico
+  temperaturaMax?: number; // °C
+  viento?: IViento;
+  radiacion?: number; // W/m2 — relevante para agua
+  humedad?: number; // % — opcional
+  presionAtmosferica?: number; // hPa — opcional
+
+  ubicacion?: ICoordenadas; // centroide consultado (el de la Localidad)
+
+  //
+  idLocalidad?: string;
+  idCliente?: string;
+  idUnidadNegocio?: string;
+  idCentroOperativo?: string;
+  //
+  fechaCreacion?: string;
+
+  // Virtuals
+  localidad?: ILocalidad;
+  cliente?: ICliente;
+  unidadNegocio?: IUnidadNegocio;
+  centroOperativo?: ICentroOperativo;
+}
+
+////// CREATE
+type OmitirCreate =
+  | "_id"
+  | "localidad"
+  | "cliente"
+  | "unidadNegocio"
+  | "centroOperativo";
+export interface ICreateRegistroClima
+  extends Omit<Partial<IRegistroClima>, OmitirCreate> {}
+
+////// UPDATE
+type OmitirUpdate =
+  | "_id"
+  | "localidad"
+  | "cliente"
+  | "unidadNegocio"
+  | "centroOperativo";
+export interface IUpdateRegistroClima
+  extends Omit<Partial<IRegistroClima>, OmitirUpdate> {}


### PR DESCRIPTION
## Contexto

Primer incremento de **INSIDEht 2.0** (clima + vistas resumen por jerarquía UN→CO→Localidad, solo con datos existentes, foco gas). Esta es la **capa de modelo**, bloqueante del resto de los repos. Plan completo: `PLAN-INSIDEHT-2.0-CLIMA-VISTAS.md` (fase F1).

Todos los campos nuevos son **opcionales y aditivos** → no rompe consumidores.

## Cambios

### `ILocalidad` (geo)
- `ubicacion?: ICoordenadas` — centroide (para consultar clima y centrar mapa).
- `geojson?: GeoJSON` — polígono opcional de la zona (Polygon/MultiPolygon; índice 2dsphere en gas-datos).
- `origenGeometria?: "OSM" | "Manual"` + `osmRelationId?` — soporta las 2 vías de carga (import OSM asistido + dibujo manual).
- **La geografía vive SOLO en Localidad.** UN/CO no tienen geometría propia: agregan/sectorizan hacia arriba desde sus Localidades.

### `registro-clima.ts` (nuevo)
- `IRegistroClima` — serie temporal de clima **por Localidad** (espejo de `IRegistroMedidorElectrico`), servida por el nuevo servicio `gas-api-clima` y persistida en gas-datos (upsert `idLocalidad`+`timestamp`+`tipo`+`fuente`).
- `FuenteClima` — **OpenWeatherMap** primario (MVP); `Open-Meteo`/`SMN`/`Estacion` previstos por el diseño pluggable.
- `TipoDatoClima` — `ACTUAL` | `PRONOSTICO` (fuente 1, API) | `CLIMATOLOGIA` (fuente 2, normal esperada derivada del histórico de la ubicación, por día del año).
- Variables canónicas: `temperatura`/`min`/`max`, `viento` (`IViento`), `radiacion` (relevante para agua), `humedad`/`presionAtmosferica` opcionales. `gas-api-clima` normaliza unidades.

## Notas de diseño
- El **rollup diario unificado** (consumo/presión/conteos por Localidad+día+división + origen de presión) se modela al arrancar **F3**, no acá: su forma depende de los KPIs operativos exactos.
- Consumidores (gas-datos, gas-api-cliente, front) pinnean **el commit ya mergeado** de este PR.

## Verificación
- Repo de solo-tipos (sin build por diseño). Imports resueltos con el mismo patrón que las series temporales existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)