### PR TITLE
feat(clima): ICandidatoGeoOsm (import OSM de geometria de Localidad)

### DIFF
--- a/src/interfaces/entidades/localidad.ts
+++ b/src/interfaces/entidades/localidad.ts
@@ -35,6 +35,19 @@ export interface ILocalidad {
   centroOperativo?: ICentroOperativo;
 }
 
+/**
+ * Candidato de geometria para una Localidad, obtenido del import asistido desde
+ * OpenStreetMap (Nominatim). El operador elige uno y confirma; la geometria se
+ * guarda en la Localidad con origenGeometria = "OSM". Atribucion: datos © OSM (ODbL).
+ */
+export interface ICandidatoGeoOsm {
+  nombre: string; // display_name de OSM
+  osmId: number;
+  osmType: string; // "relation" | "way" | "node"
+  ubicacion: ICoordenadas; // centroide (lat/lon de OSM)
+  geojson?: GeoJSON; // poligono, si OSM lo provee
+}
+
 // CREATE
 type OmitirCreate = "_id";
 export interface ICreateLocalidad


### PR DESCRIPTION
## Contexto
DTO compartido para el import asistido de límites de Localidad desde **OpenStreetMap (Nominatim)**, parte de F1 geo de INSIDEht 2.0. Lo produce `gas-api-cliente` (endpoint de búsqueda OSM) y lo consume `gas-web-cliente` (editor de geometría).

## Cambio
`ICandidatoGeoOsm` en `localidad.ts`: `nombre`, `osmId`, `osmType`, `ubicacion` (centroide), `geojson` (polígono opcional). Aditivo, no rompe nada.

El operador elige un candidato y confirma → la geometría se guarda con `origenGeometria = "OSM"` vía el PUT existente. Atribución ODbL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)