### PR TITLE
feat(clima): IResumenOperativoNivel (DTO vistas resumen por nivel)

### DIFF
--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -19,6 +19,7 @@ export * from "./kmz";
 export * from "./localidad";
 export * from "./registro-clima";
 export * from "./resumen-diario-localidad";
+export * from "./resumen-operativo-nivel";
 export * from "./log-nuc";
 export * from "./log-lora";
 export * from "./log-reporte";

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -1,0 +1,55 @@
+import { TipoDatoClima } from "./registro-clima";
+
+/**
+ * DTO de respuesta de las vistas RESUMEN por nivel jerarquico (INSIDEht 2.0).
+ * Lo produce gas-api-cliente (a partir del rollup diario resumendiariolocalidad
+ * + la serie de clima) y lo consume gas-web-cliente. No es una entidad.
+ */
+
+export type NivelResumen = "UnidadNegocio" | "CentroOperativo" | "Localidad";
+
+/** Punto de la serie diaria: consumo + temperatura (tendencia + correlacion). */
+export interface IPuntoSerieResumen {
+  fecha: string; // inicio del dia gas
+  volumenGasTotal?: number;
+  volumenCorregidoCorrectoras?: number;
+  consumoResidencial?: number;
+  temperaturaMedia?: number;
+  temperaturaMin?: number;
+  temperaturaMax?: number;
+}
+
+/** Clima agregado al nivel (actual o un punto de pronostico). Unidades canonicas. */
+export interface IClimaResumen {
+  fecha?: string;
+  tipo?: TipoDatoClima;
+  temperatura?: number; // °C
+  temperaturaMin?: number;
+  temperaturaMax?: number;
+  vientoVelocidad?: number; // m/s
+  radiacion?: number; // W/m2
+  humedad?: number; // %
+}
+
+export interface IResumenOperativoNivel {
+  nivel: NivelResumen;
+  id: string;
+  desde?: string;
+  hasta?: string;
+
+  // Consumo agregado del periodo (suma de las filas de rollup del nivel)
+  volumenGasTotal?: number;
+  volumenBaseCorrectoras?: number;
+  volumenCorregidoCorrectoras?: number;
+  consumoResidencial?: number;
+  cantidadCorrectoras?: number;
+  cantidadMedidoresResidenciales?: number;
+  cantidadLocalidades?: number; // localidades con dato en el periodo
+
+  // Serie diaria (consumo + temperatura) para tendencia y correlacion clima-demanda
+  serie?: IPuntoSerieResumen[];
+
+  // Clima
+  climaActual?: IClimaResumen; // ultimo dato ACTUAL, promediado al nivel
+  pronostico?: IClimaResumen[]; // PRONOSTICO a futuro (>=1 semana), por dia
+}


### PR DESCRIPTION
## Contexto
DTO compartido de las **vistas resumen** UN/CO/Localidad (F4/F5 de INSIDEht 2.0). Lo produce `gas-api-cliente` (desde el rollup `resumendiariolocalidad` + `registrosclima`) y lo consume `gas-web-cliente`.

## Contenido
`IResumenOperativoNivel`: nivel + id + período; **consumo agregado** (volumenGasTotal/corregido/base, residencial, conteos, cantidadLocalidades); **serie diaria** (`IPuntoSerieResumen`: consumo + temperatura → tendencia y correlación clima-demanda); **clima** (`IClimaResumen`: `climaActual` + `pronostico[]` ≥1 semana). `NivelResumen` = UnidadNegocio|CentroOperativo|Localidad.

Aditivo, no rompe consumidores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)