### PR TITLE
feat(clima): granularidad horaria/diaria + sensación térmica

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,24 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-27 - Granularidad del dato climático + sensación térmica
+
+- `IRegistroClima`: nuevos `granularidad?: GranularidadClima` (`"horaria" | "diaria"`) y
+  `sensacionTermica?: number` (°C). La serie horaria y la diaria se persistían ambas con
+  `tipo: "PRONOSTICO"` y sin discriminante: el promedio del día usaba 1-3 muestras
+  diurnas (nunca la madrugada) y la curva de pronóstico promediaba horas sueltas con la
+  media del día, sesgando los primeros días. Los registros previos quedan sin
+  `granularidad`: los `ACTUAL` históricos se tratan como horarios, los `PRONOSTICO` sin
+  granularidad quedan fuera de los cálculos diarios.
+- `IResumenDiarioLocalidad`: nuevos `sensacionTermicaMedia?` y `horasClima?` (horas
+  distintas con dato: 24 = día completo). El clima del día ahora se calcula agrupando
+  primero **por hora** (cada hora pesa igual y no se cuenta dos veces) y después por día.
+  Corregido el comentario de `consumoResidencial`: es el delta del acumulado
+  `valores.consumo`, no una suma de `consumoTotal`.
+- `IPuntoSerieResumen`: nuevos `sensacionTermicaMedia?` y `horasClima?`.
+  `IClimaResumen`: nuevo `sensacionTermica?`. `climaActual` pasa a ser el punto horario
+  más cercano a ahora (antes: último `ACTUAL`, hasta 6 h de atraso).
+
 ### 2026-07-24 - Consumo parcial EUW300 (agua residencial)
 - `IReporteDiarioEUW300`: agregado `consumoParcial?: number` (consumo del período =
   `consumo` de este reporte − `consumo` del reporte anterior del medidor). Lo calcula

--- a/src/interfaces/entidades/registro-clima.ts
+++ b/src/interfaces/entidades/registro-clima.ts
@@ -32,6 +32,23 @@ export type FuenteClima =
  */
 export type TipoDatoClima = "ACTUAL" | "PRONOSTICO" | "CLIMATOLOGIA";
 
+/**
+ * Resolucion temporal del dato. Discrimina la serie HORARIA de la DIARIA:
+ * ambas se persisten con `tipo: "PRONOSTICO"` y sin este campo NO se pueden
+ * separar. Mezclarlas rompe los dos calculos que dependen del clima:
+ * - el promedio diario (una media de 24 muestras horarias vs 1-3 muestras diurnas), y
+ * - la curva de pronostico (promediar horas sueltas con la media del dia sesga
+ *   los primeros dias, donde hay serie horaria, contra el resto donde no).
+ *
+ * - "horaria": una muestra por hora (instante). Es la que se promedia para el dia.
+ * - "diaria": un punto por dia con `temperatura` = media del dia + min/max.
+ *
+ * Los registros previos a este campo quedan sin `granularidad`: los `ACTUAL`
+ * historicos (poleo horario y backfill Open-Meteo) se tratan como horarios, y
+ * los `PRONOSTICO` sin granularidad se excluyen de los calculos diarios.
+ */
+export type GranularidadClima = "horaria" | "diaria";
+
 export interface IViento {
   velocidad?: number; // m/s
   direccion?: number; // grados 0-360 (de donde viene)
@@ -43,12 +60,14 @@ export interface IRegistroClima {
 
   timestamp?: string; // ISO UTC — instante del dato (o dia objetivo para PRONOSTICO/CLIMATOLOGIA)
   tipo?: TipoDatoClima;
+  granularidad?: GranularidadClima; // resolucion temporal (ver type)
   fuente?: FuenteClima;
 
   // Variables canonicas (normalizadas por gas-api-clima)
   temperatura?: number; // °C
   temperaturaMin?: number; // °C — agregados diarios / pronostico
   temperaturaMax?: number; // °C
+  sensacionTermica?: number; // °C — temperatura aparente (viento/humedad); driver de consumo
   viento?: IViento;
   radiacion?: number; // W/m2 — relevante para agua
   humedad?: number; // % — opcional

--- a/src/interfaces/entidades/resumen-diario-localidad.ts
+++ b/src/interfaces/entidades/resumen-diario-localidad.ts
@@ -33,16 +33,22 @@ export interface IResumenDiarioLocalidad {
   // Consumo / volumen de gas del dia (m3)
   volumenBaseCorrectoras?: number; // suma uncorrectedParcializado
   volumenCorregidoCorrectoras?: number; // suma correctedParcializado
-  consumoResidencial?: number; // suma consumoTotal residencial
+  consumoResidencial?: number; // delta del acumulado valores.consumo de los medidores del dia
   volumenGasTotal?: number; // corregido correctoras + residencial
   cantidadCorrectoras?: number;
   cantidadMedidoresResidenciales?: number;
 
-  // Clima del dia (canonico; desde registroclimas tipo ACTUAL)
-  temperaturaMedia?: number; // °C
-  temperaturaMin?: number; // °C
-  temperaturaMax?: number; // °C
+  // Clima del dia (canonico). Se calcula sobre la serie HORARIA del dia
+  // (granularidad "horaria", cualquier tipo), agrupando primero por hora para
+  // que cada hora pese igual y no se cuente dos veces. La serie diaria de
+  // pronostico (granularidad "diaria") NO entra: describe el dia entero, no un
+  // instante, y duplicaria el peso de ese dia.
+  temperaturaMedia?: number; // °C — media de las horas del dia
+  temperaturaMin?: number; // °C — minima horaria del dia
+  temperaturaMax?: number; // °C — maxima horaria del dia
+  sensacionTermicaMedia?: number; // °C
   vientoVelocidadMedia?: number; // m/s
+  horasClima?: number; // horas distintas con dato (calidad de la media: 24 = dia completo)
 
   // Idempotencia / control (patron estadogeneralcorrectoras)
   queryHash?: string;

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -23,6 +23,10 @@ export interface IPuntoSerieResumen {
   temperaturaMedia?: number;
   temperaturaMin?: number;
   temperaturaMax?: number;
+  sensacionTermicaMedia?: number;
+  // Horas del dia con dato climatico (24 = dia completo). Deja ver si un punto
+  // de la correlacion se apoya en una media horaria completa o en pocas muestras.
+  horasClima?: number;
 }
 
 /** Clima agregado al nivel (actual o un punto de pronostico). Unidades canonicas. */
@@ -32,6 +36,7 @@ export interface IClimaResumen {
   temperatura?: number; // °C
   temperaturaMin?: number;
   temperaturaMax?: number;
+  sensacionTermica?: number; // °C
   vientoVelocidad?: number; // m/s
   radiacion?: number; // W/m2
   humedad?: number; // %
@@ -56,6 +61,6 @@ export interface IResumenOperativoNivel {
   serie?: IPuntoSerieResumen[];
 
   // Clima
-  climaActual?: IClimaResumen; // ultimo dato ACTUAL, promediado al nivel
+  climaActual?: IClimaResumen; // punto horario mas cercano a ahora, promediado al nivel
   pronostico?: IClimaResumen[]; // PRONOSTICO a futuro (>=1 semana), por dia
 }


### PR DESCRIPTION
## Problema

La serie horaria y la diaria de clima se persisten **ambas** con `tipo: "PRONOSTICO"` y sin discriminante. Eso rompe los dos cálculos que dependen del clima:

**1. El promedio diario del rollup** filtra `tipo: "ACTUAL"`, y la ingesta horaria escribe **un solo ACTUAL por corrida** ⇒ 1-3 muestras diurnas por día, nunca la madrugada.

Medido en producción (localidad `662ba65d7f0fc0f1795ab50b`):

```
ACTUAL 26/07: 1 registro → 15:00Z (12:00 AR) 2.44 °C
ACTUAL 27/07: 1 registro → 09:00Z (06:00 AR) 5.40 °C
rollup día de gas 26/07 → Tmedia 3.92 · Tmin 2.44 · Tmax 5.40
```

El propio proveedor da `min -2.99 / max 5.24` para el 28/07: **error del orden de 7 °C en la mínima diaria**, que es justamente la entrada de los grados-día.

**2. La curva de pronóstico** promedia por día todos los `PRONOSTICO`, mezclando la media del día con horas sueltas:

| Día | Puntos | Composición | Media mostrada | `temp.day` real |
|---|--:|---|--:|--:|
| 27/07 | 24 | 1 diario + 23 horarios | 4.97 °C | 5.58 °C |
| 28/07 | 5 | 1 diario + 4 horarios | 4.87 °C | 5.13 °C |
| 29/07+ | 1 | sólo diario | correcto | — |

Los horarios por día decrecen (23 → 4 → 0) ⇒ la curva arranca sesgada y se corrige sola al día 3: **escalón artificial**.

## Cambios (aditivos)

- `IRegistroClima`: `granularidad?: GranularidadClima` (`"horaria" | "diaria"`) y `sensacionTermica?: number` (°C) — el proveedor ya la devuelve (`feels_like`) y se estaba descartando; cuesta 0 cuota.
- `IResumenDiarioLocalidad`: `sensacionTermicaMedia?` y `horasClima?` (horas distintas con dato; 24 = día completo, deja ver la calidad de la media). Documentado que el clima del día se calcula agrupando **primero por hora**, para que cada hora pese igual y no se cuente dos veces cuando una misma hora existe como `ACTUAL` y como `PRONOSTICO` (la clave de upsert incluye `tipo`).
- `IPuntoSerieResumen`: `sensacionTermicaMedia?`, `horasClima?`. `IClimaResumen`: `sensacionTermica?`. `climaActual` pasa a ser el punto horario más cercano a ahora (antes: último `ACTUAL`, hasta 6 h de atraso).
- Corregido el comentario de `consumoResidencial`: es el delta del acumulado `valores.consumo`, no una suma de `consumoTotal` (describía el cálculo viejo, el que todavía corre en TEST).

## Compatibilidad

Los registros previos quedan sin `granularidad`: los `ACTUAL` históricos (poleo horario y backfill Open-Meteo) se tratan como horarios, y los `PRONOSTICO` sin granularidad quedan **fuera** del cálculo diario. Sin migración de datos.

## Consumidores en el mismo tren

`gas-api-clima` (setea granularidad + persiste sensación térmica), `gas-datos` (agrupa por hora), `gas-api-cliente` (filtra el pronóstico diario y refresca el clima actual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)