### PR TITLE
feat(clima): helper windChillC compartido (sensación térmica derivada)

### DIFF
--- a/src/interfaces/auxiliares/clima.ts
+++ b/src/interfaces/auxiliares/clima.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers de clima. Funcion pura, sin dependencias y browser-safe: la compilan
+ * NestJS (gas-api-clima, gas-api-cliente) y Angular (gas-web-cliente).
+ */
+
+/**
+ * Sensacion termica por **wind chill** (formula JAG/TI, la que usan el NWS y
+ * Environment Canada). Temperatura en °C, viento en **m/s**. Devuelve °C.
+ *
+ * Vive aca —y no en cada servicio— porque la necesitan dos consumidores y tiene
+ * que dar el MISMO numero en los dos:
+ *
+ * 1. `gas-api-clima`, para el pronostico DIARIO: One Call 4.0 devuelve
+ *    `feels_like` identico a `temp` en todas las franjas del timeline diario
+ *    (verificado en produccion: 0 de 3949 registros diarios difieren, incluso con
+ *    6,6 m/s de viento), o sea que ese campo del proveedor no aporta nada. En el
+ *    timeline HORARIO si es real y no se toca.
+ * 2. `gas-api-cliente`, como respaldo de la serie diaria: los rollups anteriores a
+ *    que existiera el campo no tienen sensacion termica, y sin esto la serie
+ *    quedaria con un solo punto.
+ *
+ * La formula reproduce el `feels_like` horario del propio proveedor con un error
+ * de ±0,02 °C (400 muestras contra produccion), asi que el valor derivado es
+ * consistente con el que entrega OpenWeatherMap por hora.
+ *
+ * Fuera del rango de validez (T > 10 °C o viento < 4,8 km/h) la sensacion **es**
+ * la temperatura: por debajo de esa velocidad el viento no enfria. NO cubre el
+ * indice de calor (temperatura alta + humedad); para gas la franja que importa es
+ * la fria.
+ */
+export function windChillC(
+  tempC?: number | null,
+  vientoMs?: number | null,
+): number | undefined {
+  if (typeof tempC !== "number") return undefined;
+  if (typeof vientoMs !== "number") return tempC;
+  const vKmh = vientoMs * 3.6;
+  if (tempC > 10 || vKmh < 4.8) return tempC;
+  const f = Math.pow(vKmh, 0.16);
+  const wci = 13.12 + 0.6215 * tempC - 11.37 * f + 0.3965 * tempC * f;
+  return Math.round(wci * 100) / 100;
+}

--- a/src/interfaces/auxiliares/index.ts
+++ b/src/interfaces/auxiliares/index.ts
@@ -1,3 +1,4 @@
+export * from "./clima";
 export * from "./coordenadas";
 export * from "./listado";
 export * from "./queryParams";


### PR DESCRIPTION
Habilita las dos líneas de temperatura (real y sensación térmica) que faltan en el frontend.

## Por qué

One Call 4.0 devuelve `feels_like` **idéntico a `temp`** en todas las franjas del timeline **diario**. Verificado contra la respuesta cruda del proveedor:

```
temp:       {"day":3.06,"min":2.55,"max":4.77,"night":3.89,"eve":2.95,"morn":3.86}
feels_like: {"day":3.06,            "night":3.89,"eve":2.95,"morn":3.86}
wind_speed: 6.63   humidity: 97
```

Y en la base: **0 de 3949** registros diarios tienen `sensacionTermica != temperatura`. En el timeline **horario** sí es real: difiere en **7472 de 7880**, con desvíos de −6,4 a +7,0 °C.

O sea: graficar el `feels_like` diario del proveedor dibuja una línea pegada a la de temperatura.

## Qué se agrega

`windChillC(tempC, vientoMs)` — fórmula **JAG/TI** (NWS / Environment Canada). Validada contra el propio proveedor: reproduce su `feels_like` horario con un error de **±0,02 °C** en 400 muestras de producción (`|error| ≤ 0,5 °C` en el 100 % de los casos), así que el valor derivado es consistente con el que OWM entrega por hora.

Vive en modelos porque la necesitan **dos** consumidores y tiene que dar el mismo número en los dos:

1. `gas-api-clima` — sensación térmica del pronóstico diario (10 días).
2. `gas-api-cliente` — respaldo de la serie diaria: los rollups anteriores a que existiera el campo no la tienen, y sin esto la línea del gráfico de correlación queda con un solo punto.

Función pura, sin dependencias, browser-safe (la compilan NestJS y Angular). Fuera del rango de validez (T > 10 °C o viento < 4,8 km/h) devuelve la temperatura, que es lo correcto: por debajo de esa velocidad el viento no enfría. No cubre índice de calor (temperatura alta + humedad) — para gas la franja que importa es la fría.

🤖 Generated with [Claude Code](https://claude.com/claude-code)