### PR TITLE
feat(cliente): flag moduloClima para activar la sección Clima por cliente

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,14 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-27 - Módulo Clima activable por cliente
+
+- `IConfigCliente`: nuevo `moduloClima?: IModuloClima` (`{ activo?: boolean }`), mismo
+  patrón que `moduloCoberturaLorawan`. Gatea la sección "Clima" (vistas resumen) en
+  gas-web-cliente: sin el flag no aparece en el menú y la ruta `/clima` redirige. Permite
+  desplegar el frontend a producción con la funcionalidad aún sin liberar al cliente.
+  No requiere cambios en gas-datos: `config` es `@Prop({ type: Object })`.
+
 ### 2026-07-27 - Revertido: helper `windChillC`
 
 Se había agregado `auxiliares/clima.ts` con una función `windChillC` compartida entre

--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -152,6 +152,17 @@ export interface IModuloCoberturaLorawan {
   verMetricas?: boolean;
 }
 
+export interface IModuloClima {
+  /**
+   * Habilita la sección "Clima" (vistas resumen de INSIDEht 2.0) en
+   * gas-web-cliente. Si no está o es false, la feature está oculta: no aparece
+   * en el menú y la ruta redirige al inicio. Pensado como módulo activable por
+   * cliente mientras la funcionalidad se termina de pulir, para poder desplegar
+   * el frontend sin exponerla.
+   */
+  activo?: boolean;
+}
+
 export type DivisionConVistaPersonalizada = Extract<
   Division,
   "Correctoras" | "Residencial"
@@ -195,6 +206,13 @@ export interface IConfigCliente {
    * visibles se definen vía la colección AsignacionGatewayCliente.
    */
   moduloCoberturaLorawan?: IModuloCoberturaLorawan;
+
+  /**
+   * Sección "Clima" (vistas resumen por UN / Centro Operativo / Localidad).
+   * Módulo activable por cliente: mientras esté apagado, el frontend no muestra
+   * la sección aunque la versión desplegada la incluya.
+   */
+  moduloClima?: IModuloClima;
 
   /**
    * Si es true, un Admin Global puede editar la Unidad de Negocio y el Centro


### PR DESCRIPTION
## Qué

Agrega `IConfigCliente.moduloClima` (`IModuloClima { activo?: boolean }`), siguiendo el patrón de `moduloCoberturaLorawan`.

## Por qué

La sección Clima (vistas resumen de INSIDEht 2.0) está desplegada en el dominio alternativo pero todavía no lista para el cliente. Sin un flag, cualquier deploy de `gas-web-cliente` a producción la expondría, lo que bloquea otros fixes/mejoras de frontend.

Con el flag, la funcionalidad viaja en el bundle pero queda oculta hasta habilitarla por cliente desde el panel de administración.

## Notas

- No requiere cambios de schema en gas-datos: `Cliente.config` es `@Prop({ type: Object })`.
- Objeto en lugar de booleano para poder sumar sub-flags después sin romper el merge shallow de `config`.

## PRs asociados

- gas-web-admin: toggle en el formulario de cliente
- gas-web-cliente: helper `puedeVerClima()` + `ModuloClimaGuard` + ícono `thermostat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)