### PR TITLE
feat(kmz): campo urlGeoJson en IKmz

### DIFF
--- a/src/interfaces/entidades/kmz.ts
+++ b/src/interfaces/entidades/kmz.ts
@@ -8,6 +8,10 @@ export interface IKmz {
   idCentroOperativo?: string;
   nombre?: string;
   urlKmz?: string;
+  // GeoJSON pre-convertido del KMZ, generado por la API al momento del
+  // upload y subido a GCS igual que urlKmz. Opcional: KMZs anteriores a
+  // esta feature no lo tienen y el frontend cae al parseo client-side.
+  urlGeoJson?: string;
 
   // Virtuals
   cliente?: ICliente;


### PR DESCRIPTION
Etapa 2 de mejoras del mapa: la API convertirá el KMZ a GeoJSON en el upload y lo subirá a GCS; el frontend lo consumirá directo (cacheable) en lugar de descargar y parsear el KMZ en el main thread en cada visita.

- `urlGeoJson?: string` opcional junto a `urlKmz`. Los DTOs Create/Update lo heredan por `Partial<IKmz>` (sin cambios en los Omit).
- **Backwards compatible**: KMZs existentes no lo tienen; el frontend cae al parseo client-side actual. Sin coordinación de deploys.

Encadena: gas-datos (`@Prop` en schema, requerido por `Exactly<IKmz, Kmz>`) y gas-api-cliente (conversión en POST /Kmzs) pinnean este commit después del merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)