### PR TITLE
feat(resumen): DTO de tarjeta climática por hijo (IResumenClimaHijo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,18 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-28 - Tarjetas climáticas de la vista Resumen (1 pedido en vez de N)
+
+- `resumen-operativo-nivel.ts`: nuevos `IResumenClimaHijo`, `IPuntoTemperaturaResumen`,
+  `ITendenciaResumen` y `DireccionTendencia`. DTO de la grilla de drill-down de la vista
+  Resumen (Clima): describe la tarjeta de cada hijo (UN / CO / Localidad) con clima
+  actual, tendencia del pronóstico y serie de temperatura para el sparkline.
+  Lo produce `GET /resumen/hijos/:nivel` en gas-api-cliente, que resuelve **todos** los
+  hijos en una sola llamada. Antes el frontend pedía `GET /resumen/:nivel/:id` una vez
+  por tarjeta (N veces las 4 consultas a gas-datos, devolviendo `serie[30]` +
+  `pronostico[8]` para usar 6 valores).
+- Es solo clima a propósito: consumo y conteos de parque no van en la tarjeta.
+
 ### 2026-07-27 - Módulo Clima activable por cliente
 
 - `IConfigCliente`: nuevo `moduloClima?: IModuloClima` (`{ activo?: boolean }`), mismo

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -101,9 +101,11 @@ export interface IResumenClimaHijo {
   pronosticoTemperatura?: IPuntoTemperaturaResumen[];
 
   /**
-   * `false` cuando el hijo no tiene ninguna Localidad visible para el usuario.
-   * Sin esto la tarjeta no puede distinguir "no hay clima cargado para la zona"
-   * de "la zona no tiene localidades", y mostraba el mismo "Sin dato climatico".
+   * Siempre `true` en las entradas devueltas: la respuesta trae **solo** los hijos
+   * con al menos una Localidad visible para el usuario. Un hijo de la grilla que no
+   * aparezca en la respuesta no tiene localidades, y la tarjeta lo dice asi en vez
+   * de mostrar "Sin dato climatico" (que es otra cosa: hay localidades pero todavia
+   * no hay clima cargado para ellas).
    */
   tieneLocalidades?: boolean;
 }

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -64,3 +64,51 @@ export interface IResumenOperativoNivel {
   climaActual?: IClimaResumen; // punto horario mas cercano a ahora, promediado al nivel
   pronostico?: IClimaResumen[]; // PRONOSTICO a futuro (>=1 semana), por dia
 }
+
+/** Direccion de la tendencia de temperatura del pronostico. */
+export type DireccionTendencia = "sube" | "baja" | "estable";
+
+export interface ITendenciaResumen {
+  direccion: DireccionTendencia;
+  delta: number; // °C entre el inicio y el fin del pronostico
+}
+
+/**
+ * Tarjeta CLIMATICA de un hijo del nivel actual (una UN / CO / Localidad de la
+ * grilla de drill-down de la vista Resumen).
+ *
+ * Existe para que la grilla se pinte con **un solo pedido**. Antes el frontend
+ * llamaba `GET /resumen/:nivel/:id` una vez POR TARJETA: cada una de esas
+ * llamadas dispara 4 consultas a gas-datos (localidades + rollups + clima
+ * horario + pronostico) y devuelve `serie[30]` + `pronostico[8]` completos, de
+ * los que la tarjeta usaba 6 valores. Con N hijos era N veces todo el pipeline.
+ *
+ * Es deliberadamente SOLO CLIMA: el consumo y los conteos de parque no van en la
+ * tarjeta, y traerlos obligaria a leer los rollups de consumo de todos los hijos.
+ * `serieTemperatura` si sale del rollup diario, pero pidiendo unicamente
+ * `fecha` + temperatura (payload chico).
+ */
+export interface IResumenClimaHijo {
+  nivel: NivelResumen;
+  id: string;
+
+  climaActual?: IClimaResumen;
+  tendencia?: ITendenciaResumen;
+
+  /** Temperatura media diaria REAL de los ultimos dias (sparkline, mas viejo primero). */
+  serieTemperatura?: IPuntoTemperaturaResumen[];
+  /** Temperatura media diaria PRONOSTICADA (continua el sparkline hacia adelante). */
+  pronosticoTemperatura?: IPuntoTemperaturaResumen[];
+
+  /**
+   * `false` cuando el hijo no tiene ninguna Localidad visible para el usuario.
+   * Sin esto la tarjeta no puede distinguir "no hay clima cargado para la zona"
+   * de "la zona no tiene localidades", y mostraba el mismo "Sin dato climatico".
+   */
+  tieneLocalidades?: boolean;
+}
+
+export interface IPuntoTemperaturaResumen {
+  fecha: string; // ISO (dia)
+  temperatura?: number; // °C
+}


### PR DESCRIPTION
## Por qué

La grilla de drill-down de la vista Resumen (Clima) pinta una tarjeta por hijo (UN / CO / Localidad). Hoy el frontend pide `GET /resumen/:nivel/:id` **una vez por tarjeta**, y cada una de esas llamadas:

- dispara 4 consultas a gas-datos: localidades + rollups (`limit 100000`) + clima horario (`limit 2000`) + pronóstico (`limit 20000`);
- devuelve `serie[30]` + `pronostico[8]` completos, de los que la tarjeta usa 6 valores.

Con N hijos es N veces todo el pipeline. Medido en test: dos rondas completas de N pedidos por cada entrada a la vista (hay además una doble carga en el componente) y salto de alto de tarjeta de 102px → 167px cuando llega el dato, que es el parpadeo que se ve.

## Qué agrega

Solo tipos, en `resumen-operativo-nivel.ts`:

- `IResumenClimaHijo` — DTO de la tarjeta: `climaActual`, `tendencia`, `serieTemperatura` (real, sparkline), `pronosticoTemperatura` y `tieneLocalidades`.
- `IPuntoTemperaturaResumen`, `ITendenciaResumen`, `DireccionTendencia`.

`tieneLocalidades` resuelve un falso negativo actual: una UN sin localidades visibles hace que el endpoint por-nivel tire 403, el frontend lo traga en un `catch {}` vacío y muestra "Sin dato climático" para siempre.

Es **solo clima** a propósito: consumo y conteos de parque no van en la tarjeta, y traerlos obligaría a leer los rollups de consumo de todos los hijos.

## Consumidores

- `gas-api-cliente`: nuevo `GET /resumen/hijos/:nivel?padre=&dias=` (PR aparte).
- `gas-web-cliente`: tarjeta rediseñada + un solo pedido para toda la grilla (PR aparte).

Sin cambios en gas-datos: no hay entidad nueva, es un DTO de respuesta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)