### PR TITLE
Tipos del catálogo de exportación y de los jobs (padrón de puntos)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,20 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-29 - Catálogo de exportación y jobs de export
+
+- Nuevo namespace `interfaces/gas/exportacion`: descriptores del catálogo
+  (`IColumnaExportDescriptor`, `IFiltroExportDescriptor`, `IPresetColumnasExport`,
+  `ICatalogoExport`), pedido y estado del job (`ICrearExportRequest`,
+  `ICrearExportResponse`, `IExportJob`) y filtros del padrón de puntos
+  (`IFiltrosExportPuntosMedicion`). `TipoExportJob` agrega `"puntos-medicion"`.
+- El **catálogo con sus valores vive en gas-datos**
+  (`entidades/puntos-medicion-export/puntos-medicion-export.catalogo.ts`), no acá: son
+  valores runtime y romperían los servicios NestJS (ver "SOLO TIPOS" arriba). Acá solo
+  está la forma que viaja por la API.
+- `IExportJob` reemplaza las cinco copias sueltas de esa interfaz que había en el front
+  y en los services de gas-api-cliente.
+
 ### 2026-07-28 - Tarjetas climáticas de la vista Resumen (1 pedido en vez de N)
 
 - `resumen-operativo-nivel.ts`: nuevos `IResumenClimaHijo`, `IPuntoTemperaturaResumen`,

--- a/src/interfaces/gas/exportacion/index.ts
+++ b/src/interfaces/gas/exportacion/index.ts
@@ -1,0 +1,171 @@
+// Tipos del subsistema de exportación (jobs asíncronos + catálogo de columnas).
+//
+// IMPORTANTE: este paquete es SOLO TIPOS. No agregar `const`, `enum` ni
+// funciones acá: emiten JavaScript y los servicios NestJS que importan un valor
+// desde `modelos/src` rompen en runtime con MODULE_NOT_FOUND aunque lint y build
+// pasen (ya tumbó gas-api-clima v1.1.2 y gas-api-cliente v3.7.4 en producción).
+// El catálogo con sus valores vive en gas-datos.
+
+export type TipoExportJob =
+  | "registros"
+  | "reporte"
+  | "medidor-electrico"
+  | "puntos-medicion";
+
+export type EstadoExportJob =
+  | "pendiente"
+  | "procesando"
+  | "completado"
+  | "error";
+
+export type FormatoExport = "xlsx" | "csv";
+
+// Qué se escribe en el workbook. "indicadores" recorre el mismo universo pero
+// no emite las hojas de detalle.
+export type NivelDetalleExport = "indicadores" | "detalle" | "completo";
+
+export type FormatoColumnaExport =
+  | "texto"
+  | "entero"
+  | "numero"
+  | "porcentaje"
+  | "fecha"
+  | "fechaHora"
+  | "booleano"
+  | "lista"
+  | "coordenada";
+
+export type TipoWidgetFiltro =
+  | "texto"
+  | "booleano"
+  | "enum-multiple"
+  | "entidad-multiple"
+  | "rango-fechas";
+
+// Colecciones que el front puede listar para poblar un filtro de entidad.
+// No incluye cuentaClientes: no hay endpoint de listado para el usuario.
+export type EntidadFiltro =
+  | "unidadNegocios"
+  | "centroOperativos"
+  | "localidads"
+  | "cuencas"
+  | "grupos"
+  | "agrupacions"
+  | "subzonasTarifarias";
+
+export interface IColumnaExportDescriptor {
+  // Contrato estable: no se renombra ni se reusa para otro dato.
+  key: string;
+  // Presentación: es lo que sale como encabezado del Excel.
+  label: string;
+  grupo: string;
+  formato: FormatoColumnaExport;
+  // Va en el encabezado, nunca pegada al valor de la celda.
+  unidad?: string;
+  decimales?: number;
+  obligatoria?: boolean;
+  porDefecto?: boolean;
+  // PII: se filtra por rol en gas-api-cliente antes de encolar el job.
+  sensible?: boolean;
+  // Divisiones donde la columna tiene sentido; vacío o ausente = todas.
+  divisiones?: string[];
+  // Se sigue sirviendo para no romper a quien la pide, pero no se ofrece.
+  deprecada?: boolean;
+  descripcion?: string;
+}
+
+export interface IOpcionFiltroExport {
+  valor: string;
+  label: string;
+}
+
+export interface IFiltroExportDescriptor {
+  key: string;
+  label: string;
+  widget: TipoWidgetFiltro;
+  entidad?: EntidadFiltro;
+  opciones?: IOpcionFiltroExport[];
+  ayuda?: string;
+}
+
+export interface IPresetColumnasExport {
+  key: string;
+  label: string;
+  columnas: string[];
+}
+
+export interface ICatalogoExport {
+  tipo: TipoExportJob;
+  version: number;
+  // Identifica el contenido del catálogo; sirve para invalidar cachés del front.
+  hash: string;
+  columnas: IColumnaExportDescriptor[];
+  filtros: IFiltroExportDescriptor[];
+  presets: IPresetColumnasExport[];
+}
+
+export interface IFiltrosExportPuntosMedicion {
+  divisiones?: string[];
+  estados?: string[];
+  tiposAlertaActivos?: string[];
+  idsUnidadNegocio?: string[];
+  idsCentroOperativo?: string[];
+  idsLocalidad?: string[];
+  idsCuenca?: string[];
+  idsGrupo?: string[];
+  idsAgrupacion?: string[];
+  idsSubzonaTarifaria?: string[];
+  idsPuntoMedicion?: string[];
+  conDispositivo?: boolean;
+  facturable?: boolean;
+  // Por defecto los puntos "Dado de Baja" quedan fuera del padrón.
+  incluirDadosDeBaja?: boolean;
+  sinReportarDesde?: string;
+  sinReportarHasta?: string;
+  busqueda?: string;
+}
+
+export interface ICrearExportRequest {
+  tipo: TipoExportJob;
+  formato?: FormatoExport;
+  nombreArchivo?: string;
+  nivelDetalle?: NivelDetalleExport;
+  // Keys del catálogo, EN EL ORDEN en que van las columnas del Excel.
+  columnas?: string[];
+  // Hojas hijas de las relaciones N-a-N (SCADA, entradas digitales del NUC).
+  incluirHojasHijas?: boolean;
+  filtros?: IFiltrosExportPuntosMedicion;
+}
+
+export interface ICrearExportResponse {
+  jobId: string;
+  estado: EstadoExportJob;
+  filasEstimadas?: number;
+}
+
+export interface IExportJob {
+  _id?: string;
+  tipo?: TipoExportJob;
+  estado?: EstadoExportJob;
+  formato?: FormatoExport;
+  progreso?: number;
+  fechaCreacion?: string;
+  fechaInicio?: string;
+  fechaFin?: string;
+  nombreArchivo?: string;
+  urlDescarga?: string;
+  error?: string;
+  idCliente?: string;
+  idUsuario?: string;
+  username?: string;
+  // Texto legible del scope aplicado ("Localidades: 12 (Chascomús, …)"). El
+  // filtro crudo no va al Excel: una celda tiene un tope de 32.767 caracteres.
+  resumenScope?: string;
+  filas?: number;
+  cantidadPuntos?: number;
+  bytes?: number;
+  duracionMs?: number;
+  intentos?: number;
+  // Columnas que se pidieron pero se quitaron por permisos (PII).
+  columnasOmitidas?: string[];
+}

--- a/src/interfaces/gas/index.ts
+++ b/src/interfaces/gas/index.ts
@@ -8,3 +8,4 @@ export * from "./auditoria-veribox";
 export * from "./resumen.dto";
 export * from "./agrupacion";
 export * from "./resumen-reportes";
+export * from "./exportacion";

--- a/src/interfaces/tenant/usuario/permiso.ts
+++ b/src/interfaces/tenant/usuario/permiso.ts
@@ -36,9 +36,6 @@ export interface IPermiso {
   idsCuencas?: string[];
   idsAgrupaciones?: string[];
   usaLlm?: boolean;
-  // Exportación de listados/indicadores. `undefined` = se decide por rol (el
-  // comportamiento actual); `false` la deniega explícitamente.
-  puedeExportar?: boolean;
   // Populate
   unidadNegocios?: IUnidadNegocio[];
   centroOperativos?: ICentroOperativo[];

--- a/src/interfaces/tenant/usuario/permiso.ts
+++ b/src/interfaces/tenant/usuario/permiso.ts
@@ -36,6 +36,9 @@ export interface IPermiso {
   idsCuencas?: string[];
   idsAgrupaciones?: string[];
   usaLlm?: boolean;
+  // Exportación de listados/indicadores. `undefined` = se decide por rol (el
+  // comportamiento actual); `false` la deniega explícitamente.
+  puedeExportar?: boolean;
   // Populate
   unidadNegocios?: IUnidadNegocio[];
   centroOperativos?: ICentroOperativo[];


### PR DESCRIPTION
Primer paso de F1 del plan `gas/PLAN-EXPORTACIONES-INDICADORES.md`: la exportación del listado de puntos de medición con todas las columnas de detalle, estado y última alerta.

## Qué agrega

Namespace nuevo `interfaces/gas/exportacion`:

- **Catálogo servido por API**: `IColumnaExportDescriptor` (key estable + label + grupo + formato + unidad + `sensible` para PII + `divisiones` + `deprecada`), `IFiltroExportDescriptor`, `IPresetColumnasExport`, `ICatalogoExport`. El front pinta filtros y selector de columnas desde esto, sin columnas hardcodeadas.
- **Jobs**: `ICrearExportRequest` / `ICrearExportResponse` / `IExportJob`, `TipoExportJob` (agrega `puntos-medicion`), `EstadoExportJob`, `FormatoExport`, `NivelDetalleExport`.
- **Filtros del padrón**: `IFiltrosExportPuntosMedicion`.
- `IPermiso.puedeExportar?: boolean` — opcional: `undefined` mantiene el comportamiento actual (por rol), `false` deniega.

`IExportJob` reemplaza las 5 copias sueltas de esa interfaz que hoy viven en el front y en los services.

## Restricción respetada

Solo tipos: ni `const` ni `enum` (ambos emiten JS y rompen los servicios NestJS con `MODULE_NOT_FOUND` con lint y build verdes — ya pasó con clima v1.1.2 y cliente v3.7.4). Está escrito como comentario en el `index.ts` nuevo. El catálogo **con sus valores** va en gas-datos.

## Verificación

`tsc --noEmit --strict` sobre `src/index.ts` limpio. Cambios aditivos: nada existente se modifica salvo el campo opcional en `IPermiso`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)