### PR TITLE
feat: imei en config y reporte UWM-NB (payload V4 cifrado)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,14 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-30 - IMEI del UWM-NB (payload V4 cifrado)
+
+- `IDispositivoUwmNb`: nuevo `imei?: string`. El payload V4 (AES) del UWM-NB deja el
+  IMEI **en claro** (reemplaza al IMSI del V1, que pasa adentro del bloque cifrado…
+  desaparece del frame) y es la clave de lookup para resolver `claveAes` del device
+  antes de descifrar.
+- `IReporteUWMNB`: nuevo `imei?: string`; `imsi` queda como campo del payload V1.
+
 ### 2026-07-29 - Catálogo de exportación y jobs de export
 
 - Nuevo namespace `interfaces/gas/exportacion`: descriptores del catálogo

--- a/src/interfaces/entidades/configs-dispositivo/dispositivoUwmNb.ts
+++ b/src/interfaces/entidades/configs-dispositivo/dispositivoUwmNb.ts
@@ -16,6 +16,11 @@ export interface IDispositivoUwmNb {
   meterId?: string; // METER_ID, 12 díg (equiv. deviceMeterNumber; string, no number)
   deviceMeterNumber?: string; // alias/compatibilidad con el resto de medidores de agua
   imsi?: string; // IMSI de la SIM (15 díg; string para no perder ceros)
+  // IMEI del módulo (15 díg). En payload V4 (cifrado) viaja EN CLARO antes del
+  // METER_ID y es la clave de lookup para resolver `claveAes` antes de descifrar.
+  // OJO: el ejemplo del vendor trae un valor con formato IMSI (748...); confirmar
+  // si el campo es realmente IMEI (86.../35...) — no cambia el modelo, sí la carga.
+  imei?: string;
   iccid?: string; // ICCID de la SIM (opcional; string, 19-20 díg)
 
   // --- Comunicación NB-IoT/LTE-M ---

--- a/src/interfaces/entidades/valores-reporte/uwm-nb.ts
+++ b/src/interfaces/entidades/valores-reporte/uwm-nb.ts
@@ -36,7 +36,8 @@ export interface IReporteUWMNB {
   // --- Identidad / radio (crudos del frame) ---
   meterId: string; // METER_ID, 12 díg ASCII
   ip?: string; // Local_IP del device
-  imsi?: string; // IMSI de la SIM
+  imsi?: string; // IMSI de la SIM (payload V1 plano; ausente en V4)
+  imei?: string; // IMEI del módulo (payload V4 cifrado: en claro, reemplaza al IMSI)
   ciclosTx?: number; // CYCLES_TX (transmisiones totales)
   ciclosTxBad?: number; // CYCLES_TX_BAD (transmisiones fallidas)
   rssi?: number; // RSSI_SNR[0] (unidad sin confirmar; ver R4 del plan)


### PR DESCRIPTION
## Contexto

El proveedor del UWM-NB (OSE Evoluciona) mandó la spec **V4** del payload cifrado (`Payload of NB-IOT Meter - V4.xlsx`). Cambio de identidad del frame:

- El **IMEI (15 ASCII)** viaja **en claro** entre `Local_IP` y `METER_ID`.
- El **IMSI desaparece** del frame (el V1 plano lo llevaba después de `RSSI_SNR`).
- Todo lo demás (`METER_ID`…`CS`, 340 B) va dentro del bloque cifrado AES-128.

El IMEI en claro es la clave de lookup para resolver la `claveAes` del device **antes** de descifrar.

## Cambios

- `IDispositivoUwmNb`: nuevo `imei?: string`.
- `IReporteUWMNB`: nuevo `imei?: string`; `imsi` documentado como campo V1.
- `CLAUDE.md`: entrada en Cambios recientes.

Solo tipos opcionales — sin impacto en consumidores existentes.

⚠️ Pendiente con el vendor: confirmar si el campo es realmente IMEI — el ejemplo del Excel (`748010406630335`) tiene formato de IMSI uruguayo. No cambia el modelo, sí la carga del dato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)