### PR TITLE
feat(nme): demandas máximas horarias en IRegistroMedidorElectrico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,21 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-29 - Demandas máximas horarias del NME
+
+- `IRegistroMedidorElectrico`: nuevos `demandaMaxImportadaW`, `demandaMaxExportadaW`,
+  `demandaMaxImportadaT1W`, `demandaMaxExportadaT1W` (OBIS 1.6.0 / 2.6.0 / 1.6.0.1 /
+  2.6.0.1). **Snapshots en W al cierre de la hora, NO acumulados**: es la máxima desde el
+  último reset de facturación del medidor. No calcular deltas ni sumarlos.
+- Llegan por dos caminos con la misma forma: el reporte diario LoRaWAN (fPort 114/115/122/123)
+  y el backfill BLE de la app móvil (claves `dmd_w`/`dmd_exp_w`/`dmd_t1_w`/`dmd_exp_t1_w` de
+  la característica Registros `…06`).
+- Ausencia = campo **omitido** (el medidor no lista ese OBIS, o el registro es previo al
+  upgrade de firmware). El `-1` (`REGISTRO_AUSENTE`) sigue reservado al centinela
+  `0xFFFFFFFF` del path LoRa.
+- Los puertos de reporte diario ya no son fijos 110-113: son `110 + bit` del `reporte_mask`
+  configurable (ver `INTEGRACION_LORAWAN_NUBE_NME.md` §4).
+
 ### 2026-07-30 - IMEI del UWM-NB (payload V4 cifrado)
 
 - `IDispositivoUwmNb`: nuevo `imei?: string`. El payload V4 (AES) del UWM-NB deja el

--- a/src/interfaces/entidades/registro-medidor-electrico.ts
+++ b/src/interfaces/entidades/registro-medidor-electrico.ts
@@ -11,11 +11,14 @@ import { IMedidorElectrico } from './medidor-electrico';
 /**
  * Registro horario de un medidor electrico NME.
  *
- * El reporte diario del NME llega como 4 uplinks separados (fPort 110/111/112/113),
- * cada uno con hasta 24 acumulados horarios. El backend correlaciona los 4 puertos
- * por (deveui, timestamp de hora) y arma un registro por hora (upsert), guardando el
- * acumulado de cada metrica y el delta consumido en esa hora respecto del registro
- * previo. Energias en Wh / varh (acumulados little-endian, epoch UTC).
+ * El reporte diario del NME llega como un uplink por métrica habilitada
+ * (fPort = 110 + bit del reporte_mask; con el default de fábrica son 110-114),
+ * cada uno con 24 acumulados horarios. El backend correlaciona los puertos por
+ * (deveui, timestamp de hora) y arma un registro por hora (upsert), guardando el
+ * acumulado de cada metrica y el delta consumido en esa hora respecto del
+ * registro previo. Energias en Wh / varh (acumulados little-endian, epoch UTC).
+ * Las demandas maximas (fPort 114/115/122/123) son snapshots en W: se guardan
+ * tal cual, sin delta.
  *
  * Los campos de acumulado (`*Acum`) pueden valer -1 ("registro ausente"): el
  * dispositivo NO tiene el registro para ese timestamp (llega 0xFFFFFFFF en el
@@ -42,6 +45,19 @@ export interface IRegistroMedidorElectrico {
   kwhExportada?: number;
   kvarhImportada?: number;
   kvarhExportada?: number;
+  // Demanda máxima del medidor en W, SNAPSHOT al cierre de la hora (NO acumulado):
+  // es la máxima registrada desde el último reset de facturación del medidor. Si
+  // nadie lo resetea, la serie es monótona no decreciente y un salto entre dos
+  // horas indica que en esa hora se registró un pico nuevo. NO calcular deltas ni
+  // sumar estos campos.
+  //
+  // Ausencia = campo OMITIDO: el medidor no lista ese OBIS, o el registro es
+  // previo al upgrade de firmware del equipo. El valor -1 (REGISTRO_AUSENTE)
+  // queda reservado al centinela 0xFFFFFFFF del path LoRa, igual que los *Acum.
+  demandaMaxImportadaW?: number; // OBIS 1.6.0   — fPort 114 / BLE dmd_w
+  demandaMaxExportadaW?: number; // OBIS 2.6.0   — fPort 115 / BLE dmd_exp_w
+  demandaMaxImportadaT1W?: number; // OBIS 1.6.0.1 — fPort 122 / BLE dmd_t1_w
+  demandaMaxExportadaT1W?: number; // OBIS 2.6.0.1 — fPort 123 / BLE dmd_exp_t1_w
   //
   periodoIncompleto?: boolean; // count < 24 -> hubo huecos (corte/reboot)
   //


### PR DESCRIPTION
Cuatro campos nuevos en `IRegistroMedidorElectrico` para las demandas máximas horarias del NME (OBIS 1.6.0 / 2.6.0 / 1.6.0.1 / 2.6.0.1), en W y como **snapshots** al cierre de la hora — no acumulados, sin deltas.

Los consumen dos caminos con la misma forma:
- reporte diario LoRaWAN (fPort 114/115/122/123)
- backfill BLE de la app móvil (`dmd_w`/`dmd_exp_w`/`dmd_t1_w`/`dmd_exp_t1_w`)

Ausencia = campo **omitido**, no `-1`: ese valor sigue reservado al centinela `0xFFFFFFFF` del path LoRa sobre los campos `*Acum`.

Aditivo y opcional: no requiere migración. Los documentos existentes quedan sin la clave, que es exactamente el estado "sin dato".

Incluye además el arreglo de una frase desactualizada del comentario de la interfaz: los puertos del reporte diario ya no son los fijos 110-113, son `110 + bit` del `reporte_mask` configurable.

Bloquea a gas-datos y gas-api-cliente, que necesitan este merge para correr `npm run modelos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)