### PR TITLE
feat(nme): tipos de la ingesta v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,21 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-30 - Ingesta v3 del NME (ciclo A de plataforma)
+
+- `IDispositivoNme`: nuevos `reporteMask?` y `disponibleMask?` (u24 del fPort 100 de
+  11 B). El primero es configuración (qué reporta), el segundo observación (qué lista el
+  medidor). `reporteMask` **no** indica disponibilidad. `intervaloRegistroMin` queda
+  declarado pero deprecado: el firmware dejó de mandarlo en junio 2026.
+- `IRegistroMedidorElectrico`: nuevo `regresionAcumulado?` — marca la hora cuyo acumulado
+  bajó respecto del último válido. La muestra no produce delta ni avanza el baseline, así
+  que tras un recambio de medidor el equipo deja de producir deltas: este flag es cómo se
+  encuentran los equipos que esperan intervención.
+- `EstadoRecuperacionNme`: nuevo `'sin_datos'` — el equipo confirmó por fPort 34 que el día
+  no tiene registros. Terminal. **No confundir con `'agotado'`**: acá el dato no existe,
+  allá no lo pudimos traer; piden acciones opuestas.
+- `IIntentoRecuperacionNme`: nuevo `motivo?` — el motivo del fPort 34 (1/2/3).
+
 ### 2026-07-29 - Demandas máximas horarias del NME
 
 - `IRegistroMedidorElectrico`: nuevos `demandaMaxImportadaW`, `demandaMaxExportadaW`,

--- a/src/interfaces/entidades/configs-dispositivo/dispositivoNme.ts
+++ b/src/interfaces/entidades/configs-dispositivo/dispositivoNme.ts
@@ -13,7 +13,12 @@ export interface IDispositivoNme {
 
   // Config del device (fPort 100 / SET_CONFIG)
   tz?: number; // Zona horaria en horas (i8, Argentina = -3)
-  intervaloRegistroMin?: number; // Minutos entre registros (default 60)
+  /**
+   * @deprecated El firmware dejó de reportar este campo en junio 2026. Se
+   * mantiene declarado por compatibilidad; el decoder ya no lo escribe, así que
+   * los valores guardados quedan como estaban.
+   */
+  intervaloRegistroMin?: number;
   horaReporteDiario?: number; // Hora local del reporte diario (0-23)
   versionFw?: number;
   resetReason?: number; // enum esp_reset_reason_t
@@ -23,4 +28,27 @@ export interface IDispositivoNme {
   medidorOk?: boolean; // ultima lectura OK
   modoBajoConsumo?: boolean; // light sleep activo
   modoEmergencia?: boolean; // SPIFFS en fallo
+
+  /**
+   * Métricas que el equipo reporta por LoRaWAN (`reporte_mask` del fPort 100).
+   * `bit = métrica_base + 8×tarifa`; el reporte diario de cada métrica viaja por
+   * el fPort `110 + bit`. Es CONFIGURACIÓN: lo fija SET_CONFIG (o BLE).
+   *
+   * NO indica disponibilidad: una métrica puede estar habilitada y no
+   * disponible (el puerto viaja "sin dato"), o disponible y no habilitada (el
+   * equipo la registra pero no la reporta). Para disponibilidad, disponibleMask.
+   *
+   * Solo lo mandan los equipos con el fPort 100 de 11 bytes.
+   */
+  reporteMask?: number;
+
+  /**
+   * OBIS que el medidor lista realmente en su readout (`disponible_mask` del
+   * fPort 100). Mismos bits que reporteMask. Es OBSERVACIÓN, read-only.
+   * `0` = el equipo todavía no leyó el medidor (no "el medidor no entrega nada").
+   *
+   * El equipo emite un fPort 100 espontáneo (máx. 1/hora) cuando este mask
+   * cambia — p.ej. al reconfigurar el medidor para exponer el 2.6.0.
+   */
+  disponibleMask?: number;
 }

--- a/src/interfaces/entidades/recuperacion-nme.ts
+++ b/src/interfaces/entidades/recuperacion-nme.ts
@@ -22,6 +22,9 @@ export type EstadoRecuperacionNme =
   | 'encolado' // job creado en la cola de downlinks
   | 'enviado' // downlink GET_HISTORIC enviado a ChirpStack
   | 'recuperado' // el día quedó completo en registrosmedidorelectrico
+  | 'sin_datos' // el equipo confirmó que ese día no tiene registros (fPort 34
+  //               motivo 1). TERMINAL: no re-pedir nunca. Distinto de 'agotado':
+  //               acá el dato NO EXISTE, no es que no lo pudimos traer.
   | 'agotado' // se alcanzó el tope de intentos sin recuperar
   | 'error'; // último enqueue falló
 
@@ -29,6 +32,12 @@ export interface IIntentoRecuperacionNme {
   fecha?: string; // ISO del intento
   resultado?: 'ok' | 'error';
   error?: string; // mensaje si resultado = 'error'
+  /**
+   * Motivo del uplink fPort 34 que cerró el intento, si lo hubo:
+   * 1 = día terminado sin registros · 2 = día en curso · 3 = fecha futura.
+   * Con `resultado: 'ok'` (el intercambio funcionó; lo que no hay es dato).
+   */
+  motivo?: number;
 }
 
 export interface IRecuperacionNme {

--- a/src/interfaces/entidades/registro-medidor-electrico.ts
+++ b/src/interfaces/entidades/registro-medidor-electrico.ts
@@ -60,6 +60,17 @@ export interface IRegistroMedidorElectrico {
   demandaMaxExportadaT1W?: number; // OBIS 2.6.0.1 — fPort 123 / BLE dmd_exp_t1_w
   //
   periodoIncompleto?: boolean; // count < 24 -> hubo huecos (corte/reboot)
+  /**
+   * El acumulado de esta hora es MENOR que el último válido: regresión.
+   * Causas típicas: recambio de medidor (baja legítima y permanente) o un rebote
+   * transitorio del readout.
+   *
+   * La muestra se persiste pero NO produce delta, y NO avanza el baseline de la
+   * serie — por eso, tras un recambio, el equipo deja de producir deltas hasta
+   * que alguien intervenga. Este flag es cómo se encuentran esos equipos:
+   * `db.registromedidorelectricos.find({ regresionAcumulado: true })`.
+   */
+  regresionAcumulado?: boolean;
   //
   deveui?: string;
   deviceName?: string;


### PR DESCRIPTION
Tipos para el ciclo A de la ingesta v3 del NME. Aditivo: no se elimina ningún campo.

- `IDispositivoNme`: `reporteMask` (configuración: qué reporta) y `disponibleMask` (observación: qué lista el medidor). `reporteMask` **no** indica disponibilidad. `intervaloRegistroMin` se deja declarado y deprecado.
- `IRegistroMedidorElectrico`: `regresionAcumulado`, para poder encontrar los equipos cuya serie de deltas quedó trabada tras una regresión (la regla del protocolo es no re-baselinear solo).
- `EstadoRecuperacionNme`: `'sin_datos'` — el equipo confirmó por fPort 34 que el día no tiene registros. Terminal, y deliberadamente distinto de `'agotado'`.
- `IIntentoRecuperacionNme`: `motivo`.

Bloquea a gas-datos y gas-api-nme, que necesitan este merge para `npm run modelos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)