### PR TITLE
feat(nme): estado 'fecha_invalida' en la recuperación

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,19 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-31 - Estado 'fecha_invalida' en la recuperación NME (ciclo B)
+
+- `EstadoRecuperacionNme`: nuevo `'fecha_invalida'` — la plataforma pidió un día
+  futuro y el equipo lo rechazó (fPort 34 motivo 3). **Terminal**: reintentar
+  repite el error.
+- Sale de desambiguar `'error'`, que el ciclo A había dejado con dos significados
+  opuestos: el original "falló el enqueue" (transitorio, se reintenta) y el motivo
+  3 del fPort 34 (el pedido estaba mal armado, no reintentar). `'error'` vuelve a
+  significar solo lo primero.
+- **Al agregar un estado hay que darlo de alta en los tres lugares de `gas-cron`
+  que enumeran estados**: el `$nin` de `agotarFueraDeVentana`, el anti-loop del
+  detector y la pasada de cierre de auditoría.
+
 ### 2026-07-30 - Ingesta v3 del NME (ciclo A de plataforma)
 
 - `IDispositivoNme`: nuevos `reporteMask?` y `disponibleMask?` (u24 del fPort 100 de

--- a/src/interfaces/entidades/recuperacion-nme.ts
+++ b/src/interfaces/entidades/recuperacion-nme.ts
@@ -25,8 +25,11 @@ export type EstadoRecuperacionNme =
   | 'sin_datos' // el equipo confirmó que ese día no tiene registros (fPort 34
   //               motivo 1). TERMINAL: no re-pedir nunca. Distinto de 'agotado':
   //               acá el dato NO EXISTE, no es que no lo pudimos traer.
+  | 'fecha_invalida' // pedimos un día futuro (fPort 34 motivo 3). TERMINAL:
+  //                    reintentar repite el error. Distinto de 'error', que es un
+  //                    fallo TRANSITORIO del enqueue y sí se reintenta.
   | 'agotado' // se alcanzó el tope de intentos sin recuperar
-  | 'error'; // último enqueue falló
+  | 'error'; // último enqueue falló (transitorio, se reintenta)
 
 export interface IIntentoRecuperacionNme {
   fecha?: string; // ISO del intento


### PR DESCRIPTION
Desambigua `'error'`, que el ciclo A dejó con dos significados opuestos: el original *"falló el enqueue"* (transitorio, **se reintenta**) y el motivo 3 del fPort 34 (*pedimos un día futuro*, reintentar repite el error).

`'fecha_invalida'` es **terminal**. `'error'` vuelve a significar solo lo transitorio.

Aditivo: no se elimina ningún miembro del union.

Bloquea a `gas-api-nme` y `gas-cron`, que necesitan este merge para `npm run modelos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)