### PR TITLE
feat(nme): tipos de la Configuración Global «Parámetros OBIS» (ciclo C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,24 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-07-31 - Configuración Global «Parámetros OBIS» (ciclo C)
+
+- `IConfigCliente`: nuevo `parametrosObis?: IParametrosObis` — el `reporte_mask` de
+  24 bits que el cliente quiere en todos sus NME. Cuarta configuración global, al
+  lado de `sincHoraria`, `moduloClima` y `vistasPersonalizadas`.
+- Nueva `IConfigDownlinkNme` (`configDownlinkNme.ts`) + `ICreate`/`IUpdate` y los
+  types `EstadoConfigDownlinkNme` / `IIntentoConfigDownlinkNme`. Control por equipo
+  del SET_CONFIG, espejo de `IConfigDownlinkEuw300`. Colección `configDownlinkNme`
+  en gas-datos.
+- **Es de un solo tiro, NO reconciliación.** La existencia del documento de control
+  es lo que lo garantiza: la pasada de alta solo toma equipos que nunca lo tuvieron,
+  así que un mask cambiado por BLE en campo no se pisa. Se descarta a propósito la
+  reconciliación continua que recomienda la doc del firmware, porque dejaría sin
+  sentido la pantalla OBIS de la app móvil.
+- El estado nuevo `'esperando_equipo'` es para el equipo que nunca mandó un fPort
+  100: el SET_CONFIG de 4 B lleva `tz` + mask juntos y no se le inventa una zona
+  horaria. **No consume intentos.**
+
 ### 2026-07-31 - Estado 'fecha_invalida' en la recuperación NME (ciclo B)
 
 - `EstadoRecuperacionNme`: nuevo `'fecha_invalida'` — la plataforma pidió un día
@@ -142,9 +160,10 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
   opuestos: el original "falló el enqueue" (transitorio, se reintenta) y el motivo
   3 del fPort 34 (el pedido estaba mal armado, no reintentar). `'error'` vuelve a
   significar solo lo primero.
-- **Al agregar un estado hay que darlo de alta en los tres lugares de `gas-cron`
-  que enumeran estados**: el `$nin` de `agotarFueraDeVentana`, el anti-loop del
-  detector y la pasada de cierre de auditoría.
+- **Al agregar un estado hay que darlo de alta en `ESTADOS_TERMINALES`**
+  (`gas-cron/src/auxiliares/recuperacion-nme/constants.ts`), que es el único lugar
+  que los enumera desde el ciclo B. Antes eran tres listas separadas y esa
+  duplicación es justo lo que rompió `'sin_datos'`.
 
 ### 2026-07-30 - Ingesta v3 del NME (ciclo A de plataforma)
 

--- a/src/interfaces/entidades/configDownlinkNme.ts
+++ b/src/interfaces/entidades/configDownlinkNme.ts
@@ -1,0 +1,81 @@
+import { ICliente } from "../tenant/cliente.model";
+import { ILoraServer } from "../tenant/lora-server.model";
+import { IDispositivo } from "./dispositivo";
+
+/**
+ * Control y auditoría del downlink de configuración de un NME.
+ *
+ * Cada documento representa el `reporte_mask` que se pidió aplicar a un equipo y
+ * para el cual se programa un SET_CONFIG (fPort 100, 4 bytes) hacia ChirpStack.
+ * Clave lógica: `deveui` — hay a lo sumo un downlink de config vigente por
+ * equipo, el último upsert pisa al anterior.
+ *
+ * Dos productores lo crean: el fan-out de gas-api-cliente al guardar la
+ * Configuración Global, y la pasada de alta de gas-cron para un equipo nuevo.
+ *
+ * **La existencia del documento es lo que hace que esto sea de un solo tiro.**
+ * La pasada de alta solo toma equipos que NUNCA tuvieron control: si un técnico
+ * cambió el mask por BLE, el control ya existe y no se lo vuelve a pisar.
+ */
+export type EstadoConfigDownlinkNme =
+  | "pendiente" // fan-out hecho, aún no encolado
+  | "esperando_equipo" // sin tz conocida; NO consume intentos
+  | "encolado" // job creado en la cola de downlinks
+  | "enviado" // downlink en ChirpStack, esperando el fPort 100 de respuesta
+  | "confirmado" // TERMINAL: el reporteMask observado iguala al solicitado
+  | "agotado" // TERMINAL: se alcanzó el tope de intentos
+  | "error"; // falló el último enqueue; se reintenta
+
+export interface IIntentoConfigDownlinkNme {
+  fecha?: string; // ISO del intento
+  resultado?: "ok" | "error";
+  error?: string; // mensaje si resultado = 'error'
+}
+
+export interface IConfigDownlinkNme {
+  _id?: string;
+  //
+  deveui?: string;
+  deviceName?: string;
+  //
+  // Config solicitada (la que viaja en el downlink)
+  reporteMask?: number;
+  /**
+   * tz con la que se armó el downlink. El SET_CONFIG de 4 B lleva tz + mask
+   * juntos: no hay forma de mandar solo el mask. Se reenvía la que el propio
+   * equipo reportó por fPort 100.
+   */
+  tz?: number;
+  //
+  estado?: EstadoConfigDownlinkNme;
+  intentos?: number;
+  ultimoIntento?: string;
+  historialIntentos?: IIntentoConfigDownlinkNme[];
+  //
+  fechaSolicitud?: string;
+  fechaEnviado?: string;
+  fechaConfirmado?: string;
+  //
+  idLoraServer?: string;
+  //
+  idCliente?: string;
+  idUnidadNegocio?: string;
+  idCentroOperativo?: string;
+  //
+  fechaCreacion?: string;
+  fechaActualizacion?: string;
+  // Populate
+  cliente?: ICliente;
+  dispositivo?: IDispositivo;
+  loraServer?: ILoraServer;
+}
+
+////// CREATE
+type OmitirCreate = "_id" | "cliente" | "dispositivo" | "loraServer";
+export interface ICreateConfigDownlinkNme
+  extends Omit<Partial<IConfigDownlinkNme>, OmitirCreate> {}
+
+////// UPDATE
+type OmitirUpdate = "_id" | "cliente" | "dispositivo" | "loraServer";
+export interface IUpdateConfigDownlinkNme
+  extends Omit<Partial<IConfigDownlinkNme>, OmitirUpdate> {}

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -45,6 +45,7 @@ export * from "./config-notificacion";
 export * from "./registros-faltantes";
 export * from "./recuperacion-nme";
 export * from "./configDownlinkEuw300";
+export * from "./configDownlinkNme";
 export * from "./dispositivo-externo-nuc";
 export * from "./dash-general";
 export * from "./mensajes-bove";

--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -163,6 +163,17 @@ export interface IModuloClima {
   activo?: boolean;
 }
 
+export interface IParametrosObis {
+  /**
+   * reporte_mask de 24 bits que el cliente quiere en todos sus NME.
+   *
+   * Solo bits soportados por el firmware (0x00303F = bits 0-5, 12, 13). Los bits
+   * sin soporte los limpia el equipo al aplicar, así que un mask con bits de más
+   * nunca llegaría a confirmarse: gas-api-cliente los rechaza al guardar.
+   */
+  reporteMask?: number;
+}
+
 export type DivisionConVistaPersonalizada = Extract<
   Division,
   "Correctoras" | "Residencial"
@@ -213,6 +224,16 @@ export interface IConfigCliente {
    * la sección aunque la versión desplegada la incluya.
    */
   moduloClima?: IModuloClima;
+
+  /**
+   * Configuración Global «Parámetros OBIS»: qué métricas reportan los NME del
+   * cliente. Al guardarla, gas-api-cliente hace fan-out de un SET_CONFIG por
+   * equipo (ver IConfigDownlinkNme).
+   *
+   * Es de un solo tiro, NO reconciliación: si después un técnico cambia el mask
+   * de un equipo por BLE, la plataforma no lo pisa.
+   */
+  parametrosObis?: IParametrosObis;
 
   /**
    * Si es true, un Admin Global puede editar la Unidad de Negocio y el Centro


### PR DESCRIPTION
**Ciclo C de tres** del subsistema NME v3. Los ciclos A y B están mergeados; los tres se despliegan a producción juntos.

Spec y plan: `gas-api-cliente/docs/superpowers/specs/2026-07-31-parametros-obis-globales-design.md`.

## Qué agrega

- **`IConfigCliente.parametrosObis`** — el `reporte_mask` de 24 bits que el cliente quiere en todos sus NME. Cuarta configuración global, al lado de `sincHoraria`, `moduloClima` y `vistasPersonalizadas`.
- **`IConfigDownlinkNme`** — control por equipo del `SET_CONFIG`, espejo de `IConfigDownlinkEuw300`. Colección `configDownlinkNme` en gas-datos.

## Por qué el mask del cliente y el del equipo pueden diferir

El fan-out es **de un solo tiro, no reconciliación**. La doc del firmware recomienda reconciliar contra el fPort 100, pero eso leería un cambio hecho en campo como drift y lo pisaría, dejando sin sentido la pantalla OBIS de la app móvil. La existencia del documento de control es lo que lo garantiza: la pasada de alta solo toma equipos que nunca lo tuvieron.

La contrapartida es que la divergencia se muestra en el detalle del equipo.

## El estado `'esperando_equipo'`

El `SET_CONFIG` de 4 bytes lleva `tz` + mask juntos: no hay formato que mande solo el mask. Un equipo que nunca mandó un fPort 100 no tiene `tz` conocida y **no se le inventa una** — el síntoma de una zona horaria equivocada (registros corridos) no se rastrea hasta acá. Queda esperando, y **no consume intentos**.

`'error'` significa una sola cosa: falló el enqueue. El ciclo A lo dejó con dos sentidos opuestos y el B tuvo que desambiguarlo; acá no hay un segundo productor.

## De paso

Se corrige la nota del ciclo B en `CLAUDE.md`, que seguía diciendo que un estado nuevo hay que darlo de alta en tres lugares de `gas-cron`. Desde el ciclo B es uno solo (`ESTADOS_TERMINALES`).

## Bloquea

Los otros cuatro repos del ciclo importan estos tipos. **Mergear primero.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)