### PR TITLE
feat(clima): celda ERA5-Land en Localidad + DTO del día histórico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,49 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-03 - Serie climática histórica por celda (grados-día) — Modelos A
+
+Primer PR de `PLAN-GRADOS-DIA.md`. Sólo la superficie que **cruza el borde de la API**;
+el esquema del store histórico vive en las migraciones de `gas-api-clima`.
+
+- Nuevo `clima-historico.ts`: `IGridEra5` (celda de la grilla ERA5-Land 0,1° ≈ 9 km a la
+  que cae una Localidad) e `IClimaDiarioCelda` (DTO de lectura del día histórico:
+  agregados, vector de grados-día, temperatura efectiva, helada consecutiva).
+- `ILocalidad`: nuevo `gridEra5?: IGridEra5`. Lo escribe `gas-api-clima` al resolver la
+  celda. Deriva de `ubicacion`: **Localidad sin centroide = sin celda = sin histórico**,
+  hasta que cargue su geografía.
+- `FuenteClima`: nuevo `"ERA5-Land"`.
+
+**Por qué el histórico NO es una colección de Mongo.** Vive en un **PostgreSQL propio de
+`gas-api-clima`**, fuera de `gas-datos`. El motivo no es performance: **el dataset no
+tiene tenant** — es geodato público de referencia (reanálisis del Copernicus CDS), sin
+`idCliente`, sin permisos, sin ciclo de vida ligado a un cliente. La regla "todo acceso a
+DB pasa por gas-datos" gobierna datos de tenant. Es además lo que le da a `gas-api-clima`
+el módulo de **lectura** que le faltaba para ser de verdad la "API única de clima".
+
+**Se indexa por CELDA, no por Localidad**, y por eso el store crece sublinealmente: varias
+Localidades comparten celda y la serie se guarda una sola vez. Medido en PROD: las 395
+Localidades con centroide dan **353 celdas únicas** (10,6% de dedup).
+
+**`esFallback` no es un detalle interno.** ERA5-Land es *sólo tierra*: 11 de esas 353
+celdas (3,1%) caen en mar — Mar del Plata, Comodoro Rivadavia, Ushuaia, Necochea y otras
+— y se resuelven con la celda contigua (6,4 a 11,1 km). Quien lee ese dato tiene que poder
+saber que viene de un punto desplazado.
+
+**`gradosDia` es un vector por base, no un escalar.** 18,3 °C es sólo la conversión de los
+65 °F del default estadounidense; IRAM 11603 usa 18/20/22 y la base óptima real varía por
+segmento. Guardar el vector permite recalibrar sin releer el histórico. Se calculan por
+**integración horaria**, no por `(Tmax+Tmin)/2`, que subestima cuando la temperatura cruza
+la base durante el día. Y **no se promedian entre Localidades**: `max(0, base − T)` es
+convexa, así que por Jensen el HDD de una temperatura promediada queda sistemáticamente
+por debajo del promedio de los HDD.
+
+Lo que **no** entra en este PR, por no tener productor todavía: los campos de HDD en
+`IResumenDiarioLocalidad`, la extensión de `IResumenOperativoNivel` y el DTO de la normal
+climática. Van en Modelos B, cuando exista el código que los escribe.
+También se descartó agregar `"HISTORICO"` a `TipoDatoClima`: la serie histórica no se
+persiste en `registroclimas`, así que sería un valor sin productor.
+
 ### 2026-07-31 - Configuración Global «Parámetros OBIS» (ciclo C)
 
 - `IConfigCliente`: nuevo `parametrosObis?: IParametrosObis` — el `reporte_mask` de

--- a/src/interfaces/entidades/clima-historico.ts
+++ b/src/interfaces/entidades/clima-historico.ts
@@ -1,0 +1,143 @@
+import { FuenteClima } from "./registro-clima";
+
+/**
+ * Serie climatica HISTORICA por celda de grilla (INSIDEht 2.0 — grados-dia).
+ *
+ * A diferencia de `IRegistroClima` —que es la serie de PRESENTE (actual + pronostico)
+ * de OpenWeatherMap y vive en Mongo (`registroclimas`)— la serie historica vive en un
+ * **store propio de `gas-api-clima` (PostgreSQL dedicado)** y NO pasa por `gas-datos`.
+ *
+ * El motivo no es de performance: **este dataset no tiene tenant.** Es geodato publico
+ * de referencia (reanalisis ERA5-Land del Copernicus CDS), sin `idCliente`, sin permisos
+ * y sin ciclo de vida ligado a un cliente. La regla "todo acceso a DB pasa por gas-datos"
+ * gobierna datos de tenant, no esto.
+ *
+ * Lo que se declara aca es SOLO la superficie que cruza el borde de la API: el
+ * identificador de celda que se guarda en la Localidad y el DTO de lectura del diario.
+ * El esquema de las tablas (horario en buckets mensuales, diario, normal) vive en las
+ * migraciones de `gas-api-clima`.
+ *
+ * Plan: `PLAN-GRADOS-DIA.md`.
+ */
+
+/**
+ * Celda de la grilla ERA5-Land (0,1° ≈ 9 km) a la que pertenece una Localidad.
+ *
+ * La clave es DETERMINISTA a partir del centroide —redondeo a 0,1°— asi que no hace
+ * falta ninguna consulta espacial (ni PostGIS) para resolverla. Es tambien lo que hace
+ * que el store crezca de forma sublineal: **varias Localidades comparten celda y la
+ * serie se guarda una sola vez**. Medido sobre las 395 Localidades con centroide de
+ * PROD: 353 celdas unicas (10,6% de dedup).
+ *
+ * Lo escribe `gas-api-clima` al resolver la celda de cada Localidad.
+ */
+export interface IGridEra5 {
+  /** Identificador de la celda efectivamente usada. Formato: `S3450_W05880`. */
+  clave: string;
+
+  /** Centro de la celda usada, en grados. */
+  lat: number;
+  lon: number;
+
+  /**
+   * `true` si la celda del centroide cayo en MAR y hubo que caer a una vecina.
+   *
+   * ERA5-Land es **solo tierra**: una localidad costera puede tener su celda enmascarada.
+   * Medido en PROD: 11 de 353 celdas (3,1%) — Mar del Plata, Comodoro Rivadavia, Ushuaia,
+   * Necochea, Miramar, Punta Alta, Monte Hermoso, Camarones, Puerto San Julian, Puerto
+   * Santa Cruz y Cte. Piedrabuena. Las 11 se resolvieron con la celda contigua (6,4 a
+   * 11,1 km).
+   *
+   * **No es un detalle interno: se muestra.** El dato de esas Localidades viene de un
+   * punto desplazado y quien lo lee tiene que poder saberlo.
+   */
+  esFallback?: boolean;
+
+  /** Celda originalmente pedida, cuando `esFallback` es `true`. */
+  claveOriginal?: string;
+
+  /** Distancia entre el centroide de la Localidad y el centro de la celda usada (km). */
+  distanciaKm?: number;
+}
+
+/**
+ * Un dia de la serie historica de una celda, tal como lo devuelve `gas-api-clima`.
+ * NO es una entidad de Mongo: es el DTO de lectura del store historico.
+ *
+ * El dia es el **DIA-GAS** (arranca 10:00 UTC = 07:00 AR), igual que
+ * `IResumenDiarioLocalidad.fecha` y que el resto del dominio gas. Si el clima y el
+ * consumo usaran cortes distintos, la correlacion entre ambos se emborrona.
+ * Efecto colateral asumido: estos grados-dia **no coinciden exactamente** con los que
+ * publican ENARGAS o el SMN, que usan dia calendario.
+ */
+export interface IClimaDiarioCelda {
+  clave: string;
+  fecha: string; // ISO UTC — inicio del dia-gas
+
+  // Agregados del dia, calculados sobre la serie HORARIA (unidades canonicas)
+  temperaturaMedia?: number; // °C
+  temperaturaMin?: number; // °C
+  temperaturaMax?: number; // °C
+  sensacionTermicaMedia?: number; // °C — wind chill
+  vientoVelocidadMedia?: number; // m/s
+  humedadMedia?: number; // %
+  radiacionMedia?: number; // W/m2
+
+  /**
+   * Horas del dia con dato (24 = dia completo). **Es el gate de calidad**: por debajo
+   * de 20 horas el dia queda fuera de la regresion y de la normal. Un dia con 6 muestras
+   * produce un HDD que parece un numero y no lo es.
+   */
+  horas?: number;
+
+  /**
+   * Grados-dia de calefaccion, indexados por temperatura BASE en °C: `{ "18": 9.4 }`.
+   *
+   * Se publica un VECTOR y no un escalar a proposito. La base no es una constante
+   * universal: 18,3 °C es solo la conversion de los 65 °F del default estadounidense,
+   * IRAM 11603 usa 18/20/22 y la base optima real varia por segmento (Meng & Mourshed:
+   * 11,6-20,5 °C). Guardar el vector permite **recalibrar la base sin releer el
+   * historico ni volver a pegarle al proveedor**.
+   *
+   * Calculados por **integracion horaria** —`Σ_h max(0, base − T_h) / 24`—, no por
+   * `(Tmax+Tmin)/2`: el metodo de la media subestima cuando la temperatura cruza la base
+   * durante el dia, que es justo lo que pasa en media estacion.
+   *
+   * ⚠️ **No se promedian entre Localidades.** `max(0, base − T)` es convexa, asi que por
+   * Jensen el promedio de los HDD es MAYOR que el HDD de la temperatura promedio: calcular
+   * el HDD de un CO o una UN a partir de una temperatura promediada lo subestima de forma
+   * sistematica. Se calcula por celda y recien despues se agrega, **ponderando por carga**
+   * (cantidad de medidores), nunca de forma aritmetica. Sumar sobre el TIEMPO (acumulado
+   * de la temporada) si es valido; sumar sobre el ESPACIO no significa nada.
+   */
+  gradosDia?: Record<string, number>;
+
+  /** Idem `gradosDia` pero sobre la sensacion termica. Relevante en Patagonia ventosa. */
+  gradosDiaEfectivos?: Record<string, number>;
+
+  /**
+   * Temperatura efectiva: `0,5·T(d) + 0,5·T_ef(d−1)`. Modela la inercia termica de los
+   * edificios. En el modelo de demanda de ENARGAS (2020) es la variable mas predictiva
+   * —**86% de la influencia**, contra 4% de la temperatura del dia—, por lejos.
+   * Los coeficientes son los del mercado britanico y **hay que recalibrarlos** con datos
+   * locales; el principio fisico es universal, los numeros no.
+   */
+  temperaturaEfectiva?: number; // °C
+
+  /**
+   * Dias consecutivos de helada (`temperaturaMin <= 0`) hasta este dia, inclusive.
+   * Insumo de integridad de cañeria: el daño por congelamiento depende del frio
+   * SOSTENIDO, no de la minima de un dia suelto.
+   */
+  heladaConsecutivos?: number;
+
+  /**
+   * `false` mientras el dato provenga de ERA5-Land-T (near-real-time, ~5 dias de atraso,
+   * **sin control de calidad**). El consolidado sale 2-3 meses despues y **los valores
+   * cambian**: hay un job que re-ingesta la ventana movil de los ultimos 3 meses.
+   * Sin este flag, el HDD reciente discreparia en silencio del historico.
+   */
+  consolidado?: boolean;
+
+  fuente?: FuenteClima;
+}

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -18,6 +18,7 @@ export * from "./grupo";
 export * from "./kmz";
 export * from "./localidad";
 export * from "./registro-clima";
+export * from "./clima-historico";
 export * from "./resumen-diario-localidad";
 export * from "./resumen-operativo-nivel";
 export * from "./log-nuc";

--- a/src/interfaces/entidades/localidad.ts
+++ b/src/interfaces/entidades/localidad.ts
@@ -2,6 +2,7 @@ import { ICliente } from "../tenant";
 import { ICentroOperativo } from "../gas/centroOperativo";
 import { IUnidadNegocio } from "../gas/unidadNegocio";
 import { ICoordenadas, GeoJSON } from "../auxiliares/coordenadas";
+import { IGridEra5 } from "./clima-historico";
 
 /**
  * Origen de la geometria de una Localidad.
@@ -31,6 +32,14 @@ export interface ILocalidad {
   geojson?: GeoJSON; // poligono opcional de la zona (Polygon / MultiPolygon) — indice 2dsphere en gas-datos
   origenGeometria?: OrigenGeometriaLocalidad;
   osmRelationId?: number; // referencia a la relacion OSM cuando origenGeometria === "OSM"
+
+  /**
+   * Celda de la grilla ERA5-Land a la que cae el centroide. La resuelve y la escribe
+   * `gas-api-clima`; es la clave con la que se busca la serie climatica HISTORICA
+   * (grados-dia) de la Localidad. Deriva de `ubicacion`: una Localidad sin centroide
+   * no tiene celda y queda fuera del historico hasta que cargue su geografia.
+   */
+  gridEra5?: IGridEra5;
 
   // Virtuals
   cliente?: ICliente;

--- a/src/interfaces/entidades/registro-clima.ts
+++ b/src/interfaces/entidades/registro-clima.ts
@@ -16,9 +16,22 @@ import { ICoordenadas } from "../auxiliares/coordenadas";
  * solo de tipos (no se compila a JS), por eso las unidades se documentan aca.
  */
 
-/** Proveedor del dato climatico. OpenWeatherMap es el primario del MVP. */
+/**
+ * Proveedor del dato climatico.
+ *
+ * Hay DOS fuentes en produccion y cubren cosas distintas:
+ * - **OpenWeatherMap** — el PRESENTE: `ACTUAL`, `PRONOSTICO` y los tiles del mapa.
+ * - **ERA5-Land** — el PASADO: reanalisis de 9 km del Copernicus CDS, base de los
+ *   grados-dia y de la normal climatica. No vive en esta coleccion sino en el store
+ *   propio de `gas-api-clima` (ver `clima-historico.ts`).
+ *
+ * Se mantienen deliberadamente separadas: son series con sesgos distintos y **mezclarlas
+ * en un mismo calculo mete un escalon**. Un modelo entrenado contra ERA5-Land y evaluado
+ * contra OWM arrastra un offset sistematico que se lee como "el consumo viene raro".
+ */
 export type FuenteClima =
   | "OpenWeatherMap"
+  | "ERA5-Land" // reanalisis Copernicus CDS — serie historica (grados-dia, normal)
   | "Open-Meteo"
   | "SMN"
   | "Estacion"; // estacion meteorologica propia (futuro, fuera de alcance MVP)


### PR DESCRIPTION
Primer PR de `PLAN-GRADOS-DIA.md` (Modelos A). Declara **sólo la superficie que cruza el borde de la API**; el esquema del store histórico va en las migraciones de `gas-api-clima`.

## Qué agrega

- **`clima-historico.ts`** (nuevo): `IGridEra5` — la celda de la grilla ERA5-Land (0,1° ≈ 9 km) a la que cae una Localidad — e `IClimaDiarioCelda` — el DTO de lectura de un día histórico: agregados, vector de grados-día, temperatura efectiva, helada consecutiva.
- **`ILocalidad.gridEra5`**. Lo escribe `gas-api-clima` al resolver la celda. Deriva de `ubicacion`: Localidad sin centroide = sin celda = sin histórico, hasta que cargue su geografía.
- **`FuenteClima += "ERA5-Land"`**.

## Las tres decisiones que hay que entender para revisar esto

**El histórico no es una colección de Mongo.** Vive en un PostgreSQL propio de `gas-api-clima`, fuera de `gas-datos`. El motivo no es performance: **el dataset no tiene tenant**. Es geodato público de referencia (reanálisis del Copernicus CDS), sin `idCliente`, sin permisos y sin ciclo de vida ligado a un cliente. La regla de centralizar el acceso a DB en `gas-datos` gobierna datos de tenant. Es además lo que le da a `gas-api-clima` el módulo de lectura que le falta para ser de verdad la "API única de clima".

**Se indexa por celda, no por Localidad.** Por eso el store crece sublinealmente: varias Localidades comparten celda y la serie se guarda una sola vez. Medido contra PROD: las 395 Localidades con centroide dan **353 celdas únicas** (10,6% de dedup).

**`gradosDia` es un vector por base, no un escalar.** 18,3 °C es sólo la conversión de los 65 °F del default estadounidense; IRAM 11603 usa 18/20/22 y la base óptima real varía por segmento. El vector permite recalibrar sin releer el histórico. Se calculan por integración horaria, no por `(Tmax+Tmin)/2` —que subestima cuando la temperatura cruza la base durante el día— y **no se promedian entre Localidades**: `max(0, base − T)` es convexa, así que por Jensen el HDD de una temperatura promediada queda sistemáticamente por debajo del promedio de los HDD.

## `esFallback` se expone a propósito

ERA5-Land es **sólo tierra**. 11 de las 353 celdas (3,1%) caen en mar — Mar del Plata, Comodoro Rivadavia, Ushuaia, Necochea, Miramar, Punta Alta, Monte Hermoso, Camarones, Puerto San Julián, Puerto Santa Cruz, Cte. Piedrabuena — y se resuelven con la celda contigua (6,4 a 11,1 km). Quien lee ese dato tiene que poder saber que viene de un punto desplazado.

## Qué queda deliberadamente afuera

Por **no tener productor todavía**: los campos de HDD en `IResumenDiarioLocalidad`, la extensión de `IResumenOperativoNivel` y el DTO de la normal climática. Van en Modelos B, cuando exista el código que los escribe.

También se descartó agregar `"HISTORICO"` a `TipoDatoClima`: la serie histórica no se persiste en `registroclimas`, así que sería un valor sin productor.

## Verificación

- `tsc --noEmit` limpio.
- **Sólo tipos**: cero `const`/`function`/`class`/`enum` en los archivos tocados. Nada que pueda dejar un `require('modelos/src')` en el JS de un consumidor.
- Aditivo: todos los campos opcionales, ningún consumidor actual cambia de comportamiento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)