### PR TITLE
feat(nme): declarar las 18 métricas del protocolo en el registro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,28 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-03 - Registro NME: las 18 métricas del protocolo declaradas
+
+`IRegistroMedidorElectrico` suma los 26 campos de las tarifas 1 y 2 (energías T1/T2 con
+acumulado + delta + kilo, y las dos demandas de T2). Con eso están las **18 métricas** que
+define el protocolo: 6 bases × 3 tarifas, `bit = base + 8×tarifa`, fPort `110 + bit`.
+
+**Declarados a propósito sin productor.** Ningún firmware las reporta todavía
+(`INTEGRACION_LORAWAN_NUBE_NME.md` §4: "Definido, sin soporte aún" para los bits 8-11 y
+toda la tarifa 2). Se declaran igual porque **este es el paso caro** del cambio futuro:
+este repo es dependencia de todos los servicios, así que un campo nuevo son un PR acá, un
+bump en cada consumidor y un `@Prop()` en el schema de gas-datos — que es **estricto**, y
+sin el `@Prop()` Mongoose descarta el valor en silencio. Mapear el fPort en cada servicio,
+en cambio, es una línea. El día que el firmware las mande, no hay que tocar modelos.
+
+No cuesta nada: un campo opcional ausente no ocupa lugar en el documento ni pide
+migración. El `implements Exactly<IRegistroMedidorElectrico, ...>` del schema de gas-datos
+fuerza que los dos lados queden alineados.
+
+El medidor de banco ya lista dos de éstas — reporta `disponible_mask = 7199`, con los bits
+10 y 11 (`3.8.0.1` y `4.8.0.1`) encendidos: el dato existe en el medidor, falta que el
+firmware lo pueda reportar.
+
 ### 2026-08-03 - Serie climática histórica por celda (grados-día) — Modelos A
 
 Primer PR de `PLAN-GRADOS-DIA.md`. Sólo la superficie que **cruza el borde de la API**;

--- a/src/interfaces/entidades/registro-medidor-electrico.ts
+++ b/src/interfaces/entidades/registro-medidor-electrico.ts
@@ -59,6 +59,59 @@ export interface IRegistroMedidorElectrico {
   demandaMaxImportadaT1W?: number; // OBIS 1.6.0.1 — fPort 122 / BLE dmd_t1_w
   demandaMaxExportadaT1W?: number; // OBIS 2.6.0.1 — fPort 123 / BLE dmd_exp_t1_w
   //
+  // ===== Tarifas 1 y 2: declarados antes de tener productor =====
+  //
+  // Las 18 métricas del protocolo son 6 bases × 3 tarifas (`bit = base + 8×tarifa`,
+  // fPort de reporte = `110 + bit`). Arriba están las 8 que el firmware conocido
+  // reporta; lo que sigue son las 10 que el protocolo define y todavía nadie manda
+  // (`INTEGRACION_LORAWAN_NUBE_NME.md` §4: "Definido, sin soporte aún").
+  //
+  // **Están declarados a propósito, sin productor.** El día que un firmware empiece
+  // a reportarlas, el cambio caro es justamente éste: este repo es una dependencia
+  // de todos los servicios, así que sumar un campo son un PR acá, un bump de
+  // dependencia en cada consumidor y un `@Prop()` en el schema de gas-datos — que
+  // es **estricto**, y sin el `@Prop()` Mongoose descarta el valor en silencio.
+  // Comparado con eso, mapear el fPort en cada servicio es una línea.
+  //
+  // No cuesta nada tenerlos: un campo opcional ausente no ocupa lugar en el
+  // documento ni exige migración. Y el `implements Exactly<...>` del schema de
+  // gas-datos obliga a que los dos lados queden alineados.
+  //
+  // El medidor de banco ya lista dos de éstas: reporta `disponible_mask = 7199`,
+  // con los bits 10 y 11 (`3.8.0.1` y `4.8.0.1`) encendidos. El dato existe en el
+  // medidor; falta que el firmware lo pueda reportar.
+  //
+  // Tarifa 1 — energías (bits 8-11, fPorts 118-121)
+  whImportadaT1Acum?: number; // OBIS 1.8.0.1
+  whExportadaT1Acum?: number; // OBIS 2.8.0.1
+  varhImportadaT1Acum?: number; // OBIS 3.8.0.1
+  varhExportadaT1Acum?: number; // OBIS 4.8.0.1
+  whImportadaT1?: number;
+  whExportadaT1?: number;
+  varhImportadaT1?: number;
+  varhExportadaT1?: number;
+  kwhImportadaT1?: number;
+  kwhExportadaT1?: number;
+  kvarhImportadaT1?: number;
+  kvarhExportadaT1?: number;
+  // Tarifa 2 — energías (bits 16-19, fPorts 126-129)
+  whImportadaT2Acum?: number; // OBIS 1.8.0.2
+  whExportadaT2Acum?: number; // OBIS 2.8.0.2
+  varhImportadaT2Acum?: number; // OBIS 3.8.0.2
+  varhExportadaT2Acum?: number; // OBIS 4.8.0.2
+  whImportadaT2?: number;
+  whExportadaT2?: number;
+  varhImportadaT2?: number;
+  varhExportadaT2?: number;
+  kwhImportadaT2?: number;
+  kwhExportadaT2?: number;
+  kvarhImportadaT2?: number;
+  kvarhExportadaT2?: number;
+  // Tarifa 2 — demandas máximas (bits 20-21, fPorts 130-131). Snapshots en W,
+  // mismas reglas que las de arriba: no se suman ni se promedian.
+  demandaMaxImportadaT2W?: number; // OBIS 1.6.0.2
+  demandaMaxExportadaT2W?: number; // OBIS 2.6.0.2
+  //
   periodoIncompleto?: boolean; // count < 24 -> hubo huecos (corte/reboot)
   /**
    * El acumulado de esta hora es MENOR que el último válido: regresión.


### PR DESCRIPTION
## Qué

`IRegistroMedidorElectrico` suma los 26 campos de tarifas 1 y 2: las energías T1/T2 con acumulado + delta + kilo, y las dos demandas de T2. Con eso quedan declaradas las **18 métricas** del protocolo (6 bases × 3 tarifas, `bit = base + 8×tarifa`, fPort `110 + bit`).

## Por qué ahora, sin productor

Ningún firmware las reporta todavía — `INTEGRACION_LORAWAN_NUBE_NME.md` §4 marca los bits 8-11 y toda la tarifa 2 como "Definido, sin soporte aún".

Se declaran igual porque **este es el paso caro** del cambio futuro. Este repo es dependencia de todos los servicios: sumar un campo son un PR acá, un bump de dependencia en cada consumidor, y un `@Prop()` en el schema de gas-datos — que es **estricto**, y sin el `@Prop()` Mongoose descarta el valor en silencio. Mapear el fPort en cada servicio, en cambio, es una línea. El día que el firmware las mande, no hay que tocar modelos ni esperar un bump.

**No cuesta nada tenerlos:** un campo opcional ausente no ocupa lugar en el documento ni pide migración.

## No es teórico

El medidor de banco **ya lista dos de éstas**: reporta `disponible_mask = 7199`, con los bits 10 y 11 (`3.8.0.1` y `4.8.0.1`) encendidos. El dato existe en el medidor; falta que el firmware lo pueda reportar.

## Verificación

El `implements Exactly<IRegistroMedidorElectrico, RegistroMedidorElectrico>` del schema de gas-datos fuerza que los dos lados queden alineados: con el schema sin actualizar el build de gas-datos **falla** con 26 `TS2416`, y con los `@Prop()` agregados compila en cero errores. Verificado local apuntando el `modelos` de gas-datos a esta rama.

Requiere después: PR de `gas-datos` con los `@Prop()` (bloqueado por éste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)