### PR TITLE
feat(clima): grados-día en el rollup diario y en el DTO de resumen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,38 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-05 - Grados-día en el rollup diario y en el DTO de resumen
+
+Cierra el puente entre el histórico ERA5-Land —que vive en el PostgreSQL propio de
+`gas-api-clima`— y las vistas, que leen Mongo. Los grados-día se **copian** al rollup en
+vez de leerse al vuelo, para que el camino de servicio siga siendo una sola consulta.
+
+`ResumenDiarioLocalidadSchema` suma `gradosDia`, `gradosDiaEfectivos` y `gradosDiaNormal`
+(los tres como `z.record(z.string(), z.number())`, indexados por temperatura base),
+`temperaturaEfectiva`, `heladaConsecutivos`, `climaConsolidado` y `claveGridEra5`.
+
+**Se guarda el VECTOR de bases, no un escalar.** La base de grados-día todavía no está
+decidida: se calibra con consenso de cada tenant (`PLAN-GRADOS-DIA.md` §F5-bis), porque un
+ajuste puramente estadístico confundiría un shock tarifario con un cambio de comportamiento
+térmico. Con el vector guardado, cambiar la base es una decisión de **lectura** y no obliga
+a recalcular el rollup de las 395 Localidades.
+
+⚠️ **`gradosDia` NO se deriva de `temperaturaMedia` del mismo documento.** Esa temperatura
+viene de OpenWeatherMap y en PROD tiene ~1 muestra por día en la mayoría de las filas; los
+grados-día salen de ERA5-Land, con las 24 horas y por integración horaria. Son dos series
+distintas conviviendo en la misma fila.
+
+`PuntoSerieResumenSchema` suma `gradosDia` y `gradosDiaNormal` como **escalares** ya
+resueltos a la base vigente: el frontend dibuja una serie, no quince.
+`ResumenOperativoNivelSchema` suma `baseHdd`, `gradosDiaAcumulado`,
+`gradosDiaNormalAcumulado` y `desvioClimaticoPct`. `baseHdd` viaja explícita porque el
+número no se interpreta sin ella — 600 grados-día base 18 y 600 base 22 describen inviernos
+muy distintos.
+
+Se dejó afuera `baseHddAplicada` a nivel de fila del rollup: su productor es el mecanismo de
+calibración, que todavía no existe.
+
+
 ### 2026-08-04 - Ícono/color por estado configurable por cliente
 
 `IConfigCliente.iconosEstado?: Partial<Record<IEstado, IconoEstado>>` — el cliente puede

--- a/src/interfaces/entidades/resumen-diario-localidad.ts
+++ b/src/interfaces/entidades/resumen-diario-localidad.ts
@@ -58,6 +58,50 @@ export const ResumenDiarioLocalidadSchema = z.object({
   vientoVelocidadMedia: z.number().optional(), // m/s
   horasClima: z.number().optional(), // horas distintas con dato (calidad de la media: 24 = dia completo)
 
+  // ── Grados-dia (ERA5-Land) ────────────────────────────────────────────
+  // Los escribe gas-api-clima copiando el dia ya calculado de su store propio.
+  // Se COPIAN y no se leen al vuelo para que el camino de servicio de las vistas
+  // siga siendo una sola consulta a Mongo, sin cruzar a otra base.
+  //
+  // OJO: estos campos NO son la temperatura de arriba. Esa viene de la serie de
+  // OpenWeatherMap, que en PROD tiene ~1 muestra por dia en la mayoria de las
+  // filas; los grados-dia salen del reanalisis ERA5-Land, con las 24 horas.
+
+  /** Celda de la grilla que abastece a esta Localidad. Trazabilidad del dato. */
+  claveGridEra5: z.string().optional(),
+
+  /**
+   * Grados-dia de calefaccion del dia, indexados por temperatura BASE en °C:
+   * `{ "18": 9.4, "20": 11.4 }`.
+   *
+   * Se guarda el VECTOR entero y no un escalar porque la base todavia no esta
+   * decidida: se calibra con consenso de cada tenant (ver PLAN-GRADOS-DIA.md
+   * §F5-bis). Con el vector, cambiar la base es una decision de LECTURA y no
+   * obliga a recalcular el rollup de todas las Localidades.
+   */
+  gradosDia: z.record(z.string(), z.number()).optional(),
+
+  /** Idem sobre sensacion termica (wind chill). Relevante en Patagonia ventosa. */
+  gradosDiaEfectivos: z.record(z.string(), z.number()).optional(),
+
+  /**
+   * Normal 1991-2020 de ESE dia del año, mismo indexado por base. Es contra esto
+   * que se mide el desvio: sin la normal, un grado-dia suelto no dice nada.
+   */
+  gradosDiaNormal: z.record(z.string(), z.number()).optional(),
+
+  /** Temperatura efectiva: `0,5·T(d) + 0,5·T_ef(d−1)`. Inercia termica del parque. */
+  temperaturaEfectiva: z.number().optional(), // °C
+
+  /** Dias consecutivos de helada hasta este dia. Insumo de integridad de cañeria. */
+  heladaConsecutivos: z.number().optional(),
+
+  /**
+   * `false` mientras el dia provenga de ERA5-Land-T (near-real-time, sin control
+   * de calidad). El consolidado sale 2-3 meses despues y los valores CAMBIAN.
+   */
+  climaConsolidado: z.boolean().optional(),
+
   // Idempotencia / control (patron estadogeneralcorrectoras)
   queryHash: z.string().optional(),
   estado: EstadoResumenDiarioSchema.optional(),

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -33,6 +33,17 @@ export const PuntoSerieResumenSchema = z.object({
   // Horas del dia con dato climatico (24 = dia completo). Deja ver si un punto
   // de la correlacion se apoya en una media horaria completa o en pocas muestras.
   horasClima: z.number().optional(),
+
+  // ── Grados-dia, ya resueltos a la base vigente ────────────────────────
+  // El rollup guarda el vector de 15 bases; aca viaja el ESCALAR de la base que
+  // se esta usando, porque el frontend dibuja una serie, no quince. Cual es esa
+  // base la dice `baseHdd` del nivel.
+
+  /** Grados-dia del dia. Es el eje X natural de la correlacion con el consumo. */
+  gradosDia: z.number().optional(),
+
+  /** Grados-dia normales de ese dia del año. La referencia contra la que se mide. */
+  gradosDiaNormal: z.number().optional(),
 });
 export type IPuntoSerieResumen = z.infer<typeof PuntoSerieResumenSchema>;
 
@@ -67,6 +78,30 @@ export const ResumenOperativoNivelSchema = z.object({
 
   // Serie diaria (consumo + temperatura) para tendencia y correlacion clima-demanda
   serie: z.array(PuntoSerieResumenSchema).optional(),
+
+  // ── Grados-dia acumulados del periodo ─────────────────────────────────
+
+  /**
+   * Base en °C con la que se resolvieron los escalares de `serie` y de los
+   * acumulados. Viaja explicita porque el numero no se interpreta sin ella:
+   * 600 grados-dia base 18 y 600 base 22 describen inviernos muy distintos.
+   */
+  baseHdd: z.number().optional(),
+
+  /** Suma de los grados-dia del periodo. Acumular sobre el TIEMPO si es valido. */
+  gradosDiaAcumulado: z.number().optional(),
+
+  /** Suma de la normal del mismo periodo. */
+  gradosDiaNormalAcumulado: z.number().optional(),
+
+  /**
+   * Desvio del periodo respecto de lo normal, en %.
+   *
+   * Es el numero que un operador lee de un vistazo: "+10,5%" dice que el invierno
+   * viene mas duro que lo habitual, y por lo tanto cuanto del aumento de consumo
+   * es clima y no otra cosa. El grado-dia absoluto, solo, no dice nada.
+   */
+  desvioClimaticoPct: z.number().optional(),
 
   // Clima
   climaActual: ClimaResumenSchema.optional(), // punto horario mas cercano a ahora, promediado al nivel


### PR DESCRIPTION
Modelos B del `PLAN-GRADOS-DIA.md`. Cierra el puente entre el histórico ERA5-Land —que vive en el **PostgreSQL propio de `gas-api-clima`**— y las vistas, que leen Mongo.

Los grados-día se **copian** al rollup en vez de leerse al vuelo, para que el camino de servicio de las vistas siga siendo **una sola consulta** y no tenga que cruzar a otra base.

## Se guarda el vector de bases, no un escalar

`gradosDia`, `gradosDiaEfectivos` y `gradosDiaNormal` van como `z.record(z.string(), z.number())`, indexados por temperatura base.

La razón: **la base todavía no está decidida.** Se calibra con consenso de cada tenant (`PLAN-GRADOS-DIA.md` §F5-bis) — un ajuste puramente estadístico confundiría un shock tarifario con un cambio de comportamiento térmico, y con la volatilidad argentina eso no es hipotético.

Con el vector guardado, cambiar la base es una decisión de **lectura**. Si guardáramos el escalar, recalibrar obligaría a recomputar el rollup de las 395 Localidades día por día.

## ⚠️ `gradosDia` no se deriva de `temperaturaMedia` de la misma fila

Conviven dos series distintas en el mismo documento:

| Campo | Fuente | Cobertura real en PROD |
|---|---|---|
| `temperaturaMedia` | OpenWeatherMap | **~1 muestra/día** en 11.851 de 15.011 filas |
| `gradosDia` | ERA5-Land | 24 h, por integración horaria |

Quien lea esto después va a asumir que uno sale del otro. No: la temperatura de OWM en producción es prácticamente un instante diario, y por eso el histórico se trajo de otro lado.

## En el DTO viajan escalares

`PuntoSerieResumenSchema` suma `gradosDia` y `gradosDiaNormal` ya resueltos a la base vigente — el frontend dibuja una serie, no quince.

`ResumenOperativoNivelSchema` suma `baseHdd`, `gradosDiaAcumulado`, `gradosDiaNormalAcumulado` y `desvioClimaticoPct`. **`baseHdd` viaja explícita** porque el número no se interpreta sin ella: 600 grados-día base 18 y 600 base 22 describen inviernos muy distintos.

`desvioClimaticoPct` es el número que un operador lee de un vistazo. Medido en producción para el Gran La Plata, temporada 2026: **+10,5%** sobre lo normal.

## Qué queda afuera

`baseHddAplicada` a nivel de fila del rollup: su productor es el mecanismo de calibración, que todavía no existe. Misma disciplina que en Modelos A.

## Verificación

La batería completa que exige el repo tras la migración a Zod:

```
npm run build                                    ok
node -e require('./dist/index.js')               448 exports
parse real de los schemas nuevos desde dist      ok
npm run gen:json-schema -- --verbose             445 ok / 0 skipped / 0 error
npx madge --circular --extensions js dist/…      sin ciclos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)