### PR TITLE
feat(resumen): banda p10-p90 del día y desvío por hijo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,33 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-05 - Banda p10-p90 del día y desvío por hijo
+
+Lo que le faltaba al DTO para que la vista Resumen pueda dibujar los grados-día.
+
+`ResumenDiarioLocalidadSchema` suma `gradosDiaNormalP10` y `gradosDiaNormalP90` (records
+por base, igual que `gradosDiaNormal`, que es la mediana). `PuntoSerieResumenSchema` suma
+los dos escalares equivalentes.
+
+⚠️ **Los percentiles no son aditivos.** Sumar los p10 diarios NO da el p10 del acumulado:
+los desvíos diarios se cancelan a lo largo de la temporada, así que la suma da una banda
+mucho más ancha que la real y nada cae nunca afuera. La banda del acumulado se percentila
+sobre acumulados de temporada — y eso necesita antes una definición de temporada, que es
+un pendiente por cliente. Por eso estos campos son **sólo del día** y no hay acumulados
+p10/p90 en el nivel.
+
+`ResumenOperativoNivelSchema` suma `cantidadLocalidadesTotal` y
+`cantidadLocalidadesConGeografia`: sin centroide no hay celda ERA5-Land y por lo tanto no
+hay grados-día, y eso hay que poder decirlo. Son 175 Localidades de Naturgy BAN y todas
+las de Metrogas, Ecogas y Naturgy NOA; mostrarlas como `0%` sería mentir sobre miles de
+puntos. "Sin geografía cargada" pide una acción, "sin dato climático todavía" se resuelve
+solo.
+
+Nuevo `IResumenDesvioHijo` (`GET /resumen/desvio-hijos/:nivel` en gas-api-cliente),
+separado de `IResumenClimaHijo` a propósito: depende del rango de fechas (la tarjeta
+climática no, y se cachea por nivel+padre) y sale del rollup diario (la tarjeta sale de
+`registroclimas`).
+
 ### 2026-08-05 - Grados-día en el rollup diario y en el DTO de resumen
 
 Cierra el puente entre el histórico ERA5-Land —que vive en el PostgreSQL propio de

--- a/src/interfaces/entidades/resumen-diario-localidad.ts
+++ b/src/interfaces/entidades/resumen-diario-localidad.ts
@@ -90,6 +90,26 @@ export const ResumenDiarioLocalidadSchema = z.object({
    */
   gradosDiaNormal: z.record(z.string(), z.number()).optional(),
 
+  /**
+   * Percentiles 10 y 90 de la MISMA normal (`gradosDiaNormal` es la mediana),
+   * mismo indexado por base.
+   *
+   * Son la banda de lo habitual para ese dia del año: dicen si el desvio del dia
+   * entra en la variabilidad normal o se sale de ella. Sin la banda, un +30%
+   * sobre la mediana es indistinguible de un dia raro y de un dia frio de
+   * verdad — en pleno invierno la dispersion interanual de un dia suelto es
+   * enorme.
+   *
+   * ⚠️ **No son aditivos.** Sumar los p10 diarios NO da el p10 del acumulado:
+   * los desvios diarios se cancelan entre si a lo largo de la temporada, asi que
+   * la suma produce una banda mucho mas ancha que la real y nada cae nunca
+   * afuera. La banda del ACUMULADO se percentila sobre acumulados de temporada,
+   * y eso necesita primero una definicion de temporada (pendiente por cliente).
+   * Estos dos campos son para el grafico DIARIO.
+   */
+  gradosDiaNormalP10: z.record(z.string(), z.number()).optional(),
+  gradosDiaNormalP90: z.record(z.string(), z.number()).optional(),
+
   /** Temperatura efectiva: `0,5·T(d) + 0,5·T_ef(d−1)`. Inercia termica del parque. */
   temperaturaEfectiva: z.number().optional(), // °C
 

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -44,6 +44,20 @@ export const PuntoSerieResumenSchema = z.object({
 
   /** Grados-dia normales de ese dia del año. La referencia contra la que se mide. */
   gradosDiaNormal: z.number().optional(),
+
+  /**
+   * Banda p10-p90 de la normal de ese dia del año: el rango de lo habitual.
+   *
+   * Es lo que convierte el punto diario en una lectura: un dia por encima de la
+   * mediana puede seguir siendo un dia normal, y solo salirse de la banda lo
+   * hace anomalo. Sin ella el grafico diario sugiere anomalias donde solo hay
+   * variabilidad interanual.
+   *
+   * ⚠️ Es del DIA. No acumular: los percentiles no son aditivos (ver
+   * `IResumenDiarioLocalidad.gradosDiaNormalP10`).
+   */
+  gradosDiaNormalP10: z.number().optional(),
+  gradosDiaNormalP90: z.number().optional(),
 });
 export type IPuntoSerieResumen = z.infer<typeof PuntoSerieResumenSchema>;
 
@@ -75,6 +89,25 @@ export const ResumenOperativoNivelSchema = z.object({
   cantidadCorrectoras: z.number().optional(),
   cantidadMedidoresResidenciales: z.number().optional(),
   cantidadLocalidades: z.number().optional(), // localidades con dato en el periodo
+
+  /**
+   * Localidades del nivel visibles para el usuario, tengan dato o no.
+   * Con `cantidadLocalidadesConGeografia` es lo que permite distinguir los dos
+   * "sin numero" que hoy se verian iguales y son opuestos.
+   */
+  cantidadLocalidadesTotal: z.number().optional(),
+
+  /**
+   * Cuantas de esas Localidades tienen centroide cargado.
+   *
+   * **Sin centroide no hay celda ERA5-Land y por lo tanto no hay grados-dia**, ni
+   * los va a haber hasta que alguien cargue la geografia. No es un caso de borde:
+   * son 175 Localidades de Naturgy BAN y todas las de Metrogas, Ecogas y Naturgy
+   * NOA. Mostrar `0%` de desvio ahi seria mentir sobre miles de puntos; la vista
+   * tiene que poder decir "sin geografia cargada" y distinguirlo de "todavia no
+   * llego el dato climatico", que se resuelve solo.
+   */
+  cantidadLocalidadesConGeografia: z.number().optional(),
 
   // Serie diaria (consumo + temperatura) para tendencia y correlacion clima-demanda
   serie: z.array(PuntoSerieResumenSchema).optional(),
@@ -166,3 +199,41 @@ export const ResumenClimaHijoSchema = z.object({
   tieneLocalidades: z.boolean().optional(),
 });
 export type IResumenClimaHijo = z.infer<typeof ResumenClimaHijoSchema>;
+
+/**
+ * Desvio climatico de un hijo del nivel actual, para la barra comparativa.
+ *
+ * Va SEPARADO de `IResumenClimaHijo` por dos razones, y las dos importan:
+ *
+ * 1. **Depende del rango de fechas y la tarjeta no.** La grilla de tarjetas es
+ *    climatica y se cachea por (nivel, padre); si el desvio viajara adentro, cada
+ *    cambio de rango invalidaria esa cache y volveria a pedir clima horario,
+ *    pronostico y sparklines que no cambiaron.
+ * 2. **Sale de otra fuente.** La tarjeta se arma con `registroclimas`; esto sale
+ *    del rollup diario, con la misma agregacion ponderada del nivel.
+ *
+ * Es el gráfico que responde "¿a que UN le esta pegando el frio?": el grado-dia
+ * ABSOLUTO no sirve para eso —entre celdas de una misma UN la amplitud llega al
+ * 68%, asi que ordenar por absoluto ordena por geografia, no por anomalia—, pero
+ * el desvio si, porque cada celda se compara contra SU propia normal y eso cancela
+ * la heterogeneidad geografica.
+ */
+export const ResumenDesvioHijoSchema = z.object({
+  nivel: NivelResumenSchema,
+  id: z.string(),
+
+  /** Base en °C con la que se resolvieron los acumulados. Ver `baseHdd` del nivel. */
+  baseHdd: z.number().optional(),
+
+  gradosDiaAcumulado: z.number().optional(),
+  gradosDiaNormalAcumulado: z.number().optional(),
+  desvioClimaticoPct: z.number().optional(),
+
+  /**
+   * Ninguna Localidad del hijo tiene centroide: no va a tener grados-dia hasta que
+   * se cargue la geografia. Se distingue del hijo que si tiene celda pero todavia
+   * no tiene dato — el primero necesita una accion, el segundo se resuelve solo.
+   */
+  sinGeografia: z.boolean().optional(),
+});
+export type IResumenDesvioHijo = z.infer<typeof ResumenDesvioHijoSchema>;


### PR DESCRIPTION
Cierra el hueco de datos que impide dibujar los grados-día en la vista Resumen. Es el primer PR de la cadena (modelos → gas-datos / gas-api-clima / gas-api-cliente → gas-web-cliente).

## Qué agrega

| Schema | Campos |
|---|---|
| `ResumenDiarioLocalidad` | `gradosDiaNormalP10`, `gradosDiaNormalP90` (records por base) |
| `PuntoSerieResumen` | los dos escalares equivalentes, resueltos a la base vigente |
| `ResumenOperativoNivel` | `cantidadLocalidadesTotal`, `cantidadLocalidadesConGeografia` |
| nuevo `IResumenDesvioHijo` | desvío por hijo para la barra comparativa |

## Decisiones

**No hay acumulados p10/p90, a propósito.** Los percentiles no son aditivos: sumar los p10 diarios no da el p10 del acumulado, porque los desvíos diarios se cancelan a lo largo de la temporada. La suma da una banda mucho más ancha que la real y nada cae nunca afuera. La banda del acumulado se percentila sobre acumulados de temporada, y eso necesita antes una definición de temporada (pendiente por cliente, probablemente por latitud).

**El conteo de Localidades con centroide** es lo que permite distinguir dos "sin número" que hoy se verían iguales y son opuestos: sin centroide no hay celda ERA5-Land y no va a haber grados-día hasta que se cargue la geografía (175 Localidades de Naturgy BAN, todas las de Metrogas, Ecogas y Naturgy NOA). Mostrar `0%` ahí sería mentir sobre miles de puntos.

**`IResumenDesvioHijo` separado de `IResumenClimaHijo`**: depende del rango de fechas (la tarjeta climática no, y se cachea por nivel+padre) y sale del rollup diario (la tarjeta sale de `registroclimas`). Meterlo adentro invalidaría esa caché en cada cambio de rango.

## Verificación

```
npm run build                                        ✅
require('./dist/index.js')                           ✅ 449 exports
npm run gen:json-schema --verbose                    ✅ ok=446 skipped=0 error=0
npx madge --circular --extensions js dist/interfaces  ✅ 0 ciclos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)