### PR TITLE
feat(resumen): grados-día de relleno desde OpenWeatherMap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,30 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-06 - Grados-día de relleno desde OpenWeatherMap
+
+ERA5-Land publica con ~5 días de atraso, así que el último tramo del rango —el que se mira
+para saber cómo viene el invierno— queda vacío. Desde el **27-jul-2026** la serie horaria de
+OWM cubre las **24 h** de cada Localidad (antes eran 1 a 4 muestras por día), así que permite
+el mismo cálculo por integración horaria, y con resolución por Localidad en vez de por celda
+de 9 km.
+
+`ResumenDiarioLocalidad` suma `gradosDiaOwm` (record por base, igual que el de ERA5) y
+`PuntoSerieResumen` suma `gradosDiaProvisorio`. **Campo aparte, no reemplazo**: cuando llega
+ERA5 gana solo, sin borrar nada.
+
+**No cuesta requests**: el dato ya está en `registroclimas`. Se calcula en el `$group` por
+hora que el rollup ya ejecuta.
+
+⚠️ **Las dos series no son intercambiables.** Medido sobre 158 pares Localidad-día con ambas
+completas: OWM corre **+0,48 °C de media** (mediana +0,25, p90 +1,90; 31% por encima de 1 °C)
+más cálido que ERA5 — en base 18, ~0,3-0,5 grados-día por día. Como la normal sale de ERA5,
+ese sesgo entra directo en el desvío. De ahí la bandera: lo que el lector necesita saber es
+que **ese punto se va a mover**.
+
+Mismo gate de calidad que ERA5: sólo con **≥ 20 horas** del día.
+
+
 ### 2026-08-05 - Banda p10-p90 del día y desvío por hijo
 
 Lo que le faltaba al DTO para que la vista Resumen pueda dibujar los grados-día.

--- a/src/interfaces/entidades/resumen-diario-localidad.ts
+++ b/src/interfaces/entidades/resumen-diario-localidad.ts
@@ -110,6 +110,31 @@ export const ResumenDiarioLocalidadSchema = z.object({
   gradosDiaNormalP10: z.record(z.string(), z.number()).optional(),
   gradosDiaNormalP90: z.record(z.string(), z.number()).optional(),
 
+  /**
+   * Grados-dia calculados desde la serie horaria de **OpenWeatherMap**, mismo indexado
+   * por base. Es el RELLENO de la punta, no un reemplazo de `gradosDia`.
+   *
+   * Existe porque ERA5-Land publica con ~5 dias de atraso y el ultimo tramo del rango
+   * —el que se mira para saber como viene el invierno— queda vacio. La serie horaria de
+   * OWM cubre las 24 h de cada Localidad desde el 27-jul-2026, asi que permite el MISMO
+   * calculo por integracion horaria y encima con resolucion por Localidad, no por celda
+   * de 9 km.
+   *
+   * **No cuesta requests**: el dato ya esta en `registroclimas`, lo trae la ingesta
+   * horaria que corre igual. Se calcula en el pipeline del rollup, que ya agrupa por hora.
+   *
+   * ⚠️ **No es intercambiable con `gradosDia`.** Medido sobre 158 pares Localidad-dia con
+   * ambas series completas: OWM corre **+0,48 °C de media** (mediana +0,25) mas calido que
+   * ERA5, con p90 en +1,90 y un 31% de los dias por encima de 1 °C. En base 18 son
+   * ~0,3-0,5 grados-dia por dia. Como la normal sale de ERA5, ese sesgo entra directo en
+   * el desvio. Quien lo lea tiene que saber de donde viene: ver
+   * `IPuntoSerieResumen.gradosDiaProvisorio`.
+   *
+   * Mismo gate de calidad que ERA5: solo se calcula con **>= 20 horas** del dia. Con menos
+   * muestras el promedio no describe el dia y produciria un numero que parece un dato.
+   */
+  gradosDiaOwm: z.record(z.string(), z.number()).optional(),
+
   /** Temperatura efectiva: `0,5·T(d) + 0,5·T_ef(d−1)`. Inercia termica del parque. */
   temperaturaEfectiva: z.number().optional(), // °C
 

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -46,6 +46,20 @@ export const PuntoSerieResumenSchema = z.object({
   gradosDiaNormal: z.number().optional(),
 
   /**
+   * El grado-dia del dia **no** salio de ERA5-Land sino de la serie horaria de
+   * OpenWeatherMap, porque ERA5 todavia no publico ese dia (~5 dias de atraso).
+   *
+   * Viaja como bandera y no como texto de fuente porque lo que el lector necesita saber
+   * es una sola cosa: **este punto se va a mover** cuando llegue el dato definitivo. El
+   * sesgo medido entre las dos series es de +0,25 a +0,48 °C, o sea ~0,3-0,5 grados-dia
+   * por dia, y la normal contra la que se compara sigue siendo la de ERA5.
+   *
+   * En un nivel que agrega varias Localidades alcanza con que UNA aporte dato provisorio
+   * para que el punto lo sea: el agregado ya quedo contaminado.
+   */
+  gradosDiaProvisorio: z.boolean().optional(),
+
+  /**
    * Banda p10-p90 de la normal de ese dia del año: el rango de lo habitual.
    *
    * Es lo que convierte el punto diario en una lectura: un dia por encima de la


### PR DESCRIPTION
Primer PR de la cadena que cierra el bache de la punta con la serie que ya tenemos.

## Por qué

ERA5-Land publica con ~5 días de atraso, así que el último tramo del rango —el que se mira para saber cómo viene el invierno— queda vacío. Hasta ahora eso no tenía arreglo: la serie de OWM traía **1 a 4 muestras por día** y con eso no se integra un grado-día.

**Desde el 27-jul-2026 trae las 24 h de cada Localidad** (26-jul: 18; 25-jul: 3-4), así que ahora sí permite el mismo cálculo por integración horaria — y con resolución **por Localidad** en vez de por celda de 9 km compartida.

## Qué agrega

| Schema | Campo |
|---|---|
| `ResumenDiarioLocalidad` | `gradosDiaOwm` (record por base, igual que el de ERA5) |
| `PuntoSerieResumen` | `gradosDiaProvisorio` (bandera) |

**Campo aparte, no reemplazo.** Cuando ERA5 publica el día, gana solo, sin borrar ni pisar nada.

## No cuesta requests

El dato ya está en `registroclimas` — lo trae la ingesta horaria que corre igual — y el cálculo entra en el `$group` por hora que el rollup ya ejecuta. El consumo de OWM sigue en 1.580 requests/día hábil (3 corridas horarias + pronóstico, × 395 localidades).

## El costo real: las dos series no son intercambiables

Medido sobre **158 pares Localidad-día** con ambas series completas (27 y 28-jul, único solapamiento disponible):

```
T media OWM − ERA5:  media +0,48 °C · mediana +0,25 °C · p10 −0,70 · p90 +1,90
                     31% difiere >1 °C · 9% >2 °C
```

En base 18 son ~0,3-0,5 grados-día por día. Como **la normal sale de ERA5**, ese sesgo entra directo en el desvío de esos días.

Por eso la bandera. Es booleana y no un nombre de fuente porque lo que el lector necesita saber es una sola cosa: **ese punto se va a mover**. En un nivel que agrega varias Localidades alcanza con que una aporte dato provisorio para que el punto lo sea — el agregado ya quedó contaminado.

Mismo gate de calidad que ERA5: sólo con **≥ 20 horas** del día.

## Verificación

```
npm run build                                        ✅
require('./dist/index.js')                           ✅ 449 exports
npm run gen:json-schema --verbose                    ✅ ok=446 error=0
npx madge --circular --extensions js dist/interfaces  ✅ 0 ciclos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)