### PR TITLE
feat(alerta): tipos para las alarmas que el SML/WRC ya reporta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,38 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-06 - Cinco tipos de alerta para las alarmas del SML/WRC
+
+`TipoAlertaSchema` suma `"Flujo inverso"`, `"Falla de medición"`, `"Medidor detenido"`,
+`"Fuga"` y `"Sobrecaudal"`. Son alarmas que el firmware **ya reporta en cada uplink** y que
+`gas-api-wrc` **ya decodifica** (`/82/0`, 25 keys) y gas-sml **ya persiste** en cada reporte
+horario — pero que no tenían ningún tipo de alerta donde expresarse, así que nadie las lee.
+Análisis completo en `/ANALISIS-ALARMAS-SML-WRC.md` (raíz del sistema).
+
+Medido en PROD sobre 3.052 equipos: 254 con `metering fault`, 321 con `meter_stop_alarm`,
+236 con `leakage_alarm`, 90 con `reverse_flow_alarm`, 9 con `over_flow_alarm`. Ninguno
+generó una sola alerta.
+
+⚠️ **`metering_error_status` es un bitfield, no un enum** (`/80/0` key 6: bit 1 = metering
+data error, bit 4 = metering fault). Se lee `(err & 16) !== 0`. En PROD hoy sólo toma los
+valores 0 y 16, pero compararlo con `=== 16` se rompe el día que el firmware prenda bit 1.
+
+⚠️ **`meter_stop_alarm` y `leakage_alarm` no son alertables tal cual.** Su criterio lo fija
+la configuración del propio equipo (`/82/0` key 14 caudal mínimo de fuga, key 15 duración de
+fuga, key 16 duración de consumo cero), así que el mismo flag no significa lo mismo en dos
+equipos con distinta config. Verificado en PROD: `SML-4G-2601270290` tiene
+`meter_stop_alarm=1` con consumo 0 y acumulado 0,08 m³ — es una casa deshabitada, no una
+falla. Hay que relevar los umbrales del parque antes de conectarlas.
+
+**El enum es único para todo el sistema y tiene tres listas divergentes** (hallazgo A7 de
+`/ANALISIS-RECLAMO-SML-CAMUZZI.md`): el modelo Mongoose de puntos en gas-datos, el filtro del
+listado en gas-web-cliente y el catálogo de export en gas-datos. Un tipo nuevo que no se dé
+de alta en las tres queda invisible en los filtros.
+
+No se tocó `TipoAlertaEnvioSchema` (`envio-sms.ts`): son las categorías que disparan canal
+externo (SMS/push), no tiene ninguna categoría residencial, y qué alertas ameritan
+notificación externa es una decisión de producto que todavía no se tomó.
+
 ### 2026-08-06 - Grados-día de relleno desde OpenWeatherMap
 
 ERA5-Land publica con ~5 días de atraso, así que el último tramo del rango —el que se mira

--- a/src/interfaces/entidades/alerta.ts
+++ b/src/interfaces/entidades/alerta.ts
@@ -15,6 +15,18 @@ import type { IMedidorElectrico } from "./medidor-electrico";
 export const EstadoAlertaSchema = z.enum(["Cerrado", "Activo"]);
 export type IEstadoAlerta = z.infer<typeof EstadoAlertaSchema>;
 
+// Los cinco últimos son alarmas que el firmware del SML/WRC ya reporta en cada
+// uplink y que hasta ahora no tenían dónde expresarse:
+//   Flujo inverso     <- alarm.reverse_flow_alarm
+//   Falla de medición <- meter_info.metering_error_status (bitfield: bit 1 =
+//                        metering data error, bit 4 = metering fault). Se lee por
+//                        máscara, NUNCA comparando el entero.
+//   Medidor detenido  <- alarm.meter_stop_alarm
+//   Fuga              <- alarm.leakage_alarm
+//   Sobrecaudal       <- alarm.over_flow_alarm
+// El criterio de "medidor detenido" y "fuga" lo fija la configuración del equipo
+// (/82/0 keys 14/15/16), así que el mismo flag no significa lo mismo en dos equipos
+// con distinta configuración.
 export const TipoAlertaSchema = z.enum([
   "Sin Reportar",
   "Valor Alto",
@@ -26,6 +38,11 @@ export const TipoAlertaSchema = z.enum([
   "Ataque magnético",
   "Alerta de Entrada Digital",
   "Alarma Correctora",
+  "Flujo inverso",
+  "Falla de medición",
+  "Medidor detenido",
+  "Fuga",
+  "Sobrecaudal",
 ]);
 export type ITipoAlerta = z.infer<typeof TipoAlertaSchema>;
 


### PR DESCRIPTION
## Qué

`TipoAlertaSchema` suma cinco valores: **Flujo inverso**, **Falla de medición**, **Medidor detenido**, **Fuga** y **Sobrecaudal**.

## Por qué

`gas-api-wrc` ya decodifica las 25 keys de `/82/0` y gas-sml ya copia el objeto `alarm` entero a cada reporte horario. Pero `checkAlertasWRC` (`gas-sml/src/entidades/uplinks/uplinks.service.ts:1432-1665`) sólo mira batería, anti-tamper y ataque magnético — y no había ningún tipo de alerta donde expresar el resto.

Medido en PROD sobre 3.052 equipos con reporte del 05-06/08:

| Señal del equipo | Equipos en 1 | Alertas generadas |
|---|---:|---:|
| `metering_error_status` bit 4 (metering fault) | 254 | 0 |
| `meter_stop_alarm` | 321 | 0 |
| `leakage_alarm` | 236 | 0 |
| `reverse_flow_alarm` | 90 | 0 |
| `over_flow_alarm` | 9 | 0 |

Disparador: el reclamo del SML-270105, donde el equipo venía declarando `metering fault` desde el **segundo día de servicio** y la falla llegó por mail cinco semanas después.

## Detalles que importan

⚠️ **`metering_error_status` es un bitfield, no un enum.** Spec V2.17 `/80/0` key 6: bit 1 = metering data error, bit 4 = metering fault. Se lee `(err & 16) !== 0`. En PROD hoy sólo toma 0 y 16, pero compararlo con `=== 16` se rompe cuando el firmware prenda bit 1.

⚠️ **`meter_stop_alarm` y `leakage_alarm` se declaran pero NO son alertables tal cual.** Su criterio lo fija la config del propio equipo (`/82/0` key 14 caudal mínimo de fuga, key 15 duración de fuga, key 16 duración de consumo cero), así que el mismo flag no significa lo mismo en dos equipos con distinta config. Verificado: `SML-4G-2601270290` tiene `meter_stop_alarm=1` con consumo 0 y acumulado 0,08 m³ — casa deshabitada, no falla. Hay que relevar los umbrales del parque antes de conectarlas.

**Deuda que este PR NO cierra:** el enum es único para todo el sistema y tiene tres listas divergentes (modelo Mongoose de puntos en gas-datos, filtro del listado en gas-web-cliente, catálogo de export en gas-datos — hallazgo A7). Cada tipo nuevo hay que darlo de alta en las tres o queda invisible en los filtros. Va en los PRs de los consumidores.

No se tocó `TipoAlertaEnvioSchema` (`envio-sms.ts`): son las categorías de canal externo (SMS/push), no tiene ninguna categoría residencial, y qué alertas ameritan notificación externa es una decisión de producto pendiente.

## Verificación

```
npm run build                                        ✅
node -e "require('./dist/index.js')"                 ✅ 449 exports
npm run gen:json-schema -- --verbose                 ✅ ok=446 skipped=0 error=0
npx madge --circular --extensions js dist/interfaces ✅ 0 ciclos
```

Análisis completo: `/ANALISIS-ALARMAS-SML-WRC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)