### PR TITLE
feat(resumen): grados-día proyectados desde el pronóstico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,26 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-06 - Grados-día proyectados desde el pronóstico
+
+`IResumenOperativoNivel.pronosticoGradosDia` (nuevo `IPuntoGradosDiaPronostico`): los
+próximos ~8 días de grados-día, para extender la curva.
+
+**Va aparte de `serie` y NO entra en `gradosDiaAcumulado` ni en `desvioClimaticoPct`**: un
+desvío que mezcla medición con pronóstico deja de ser una medición, y es el número con el
+que se decide.
+
+**Se calcula por Localidad y se agrega ponderado**, igual que la serie real. Hacerlo sobre
+la temperatura ya promediada del nivel —que es lo que haría el frontend con `pronostico`—
+subestima entre **9% y 24%** (medido sobre 29 días de una UN: −9,1% desde la media, −23,6%
+desde `(Tmax+Tmin)/2`). Mismo Jensen que gobierna el resto del diseño.
+
+`integracionHoraria` distingue los dos tramos: el pronóstico horario cubre ~48 h y permite
+el método exacto; de ahí en adelante sólo hay máxima y mínima, y `(Tmax+Tmin)/2` subestima
+−2,5% (medido sobre 790 pares Localidad-día). A partir del día 3 ese sesgo queda tapado por
+la incertidumbre del pronóstico en sí, pero los dos tramos no se midieron igual y eso se dice.
+
+
 ### 2026-08-06 - Cinco tipos de alerta para las alarmas del SML/WRC
 
 `TipoAlertaSchema` suma `"Flujo inverso"`, `"Falla de medición"`, `"Medidor detenido"`,

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -89,6 +89,34 @@ export const ClimaResumenSchema = z.object({
 });
 export type IClimaResumen = z.infer<typeof ClimaResumenSchema>;
 
+/**
+ * Un dia de grados-dia PROYECTADOS desde el pronostico.
+ *
+ * Es una proyeccion, no una medicion, y por eso viaja aparte de `serie` y no entra en
+ * los acumulados ni en el desvio del nivel: el desvio mide lo que paso.
+ */
+export const PuntoGradosDiaPronosticoSchema = z.object({
+  fecha: z.string(), // inicio del dia gas
+
+  /** Ya resuelto a la base vigente (`baseHdd`), como el resto de la serie. */
+  gradosDia: z.number(),
+
+  /**
+   * El dia se calculo por **integracion horaria** y no desde `(Tmax+Tmin)/2`.
+   *
+   * El pronostico horario cubre ~48 h; de ahi en adelante solo hay maxima y minima. El
+   * metodo de la media subestima —medido sobre 790 pares Localidad-dia reales: −0,12
+   * grados-dia, −2,5%— porque ignora cuanto tiempo estuvo la temperatura bajo la base.
+   * A partir del dia 3 ese sesgo igual queda tapado por la incertidumbre del pronostico
+   * en si (±2-3 °C son ±2-3 grados-dia), pero el consumidor tiene derecho a saber que
+   * los dos tramos no se midieron igual.
+   */
+  integracionHoraria: z.boolean().optional(),
+});
+export type IPuntoGradosDiaPronostico = z.infer<
+  typeof PuntoGradosDiaPronosticoSchema
+>;
+
 export const ResumenOperativoNivelSchema = z.object({
   nivel: NivelResumenSchema,
   id: z.string(),
@@ -149,6 +177,21 @@ export const ResumenOperativoNivelSchema = z.object({
    * es clima y no otra cosa. El grado-dia absoluto, solo, no dice nada.
    */
   desvioClimaticoPct: z.number().optional(),
+
+  /**
+   * Grados-dia PROYECTADOS de los proximos dias, para extender la curva.
+   *
+   * Separado de `serie` a proposito: es una proyeccion y no entra en
+   * `gradosDiaAcumulado` ni en `desvioClimaticoPct`. Un desvio que mezcla medicion con
+   * pronostico deja de ser una medicion, y es el numero que el operador usa para decidir.
+   *
+   * Se calcula **por Localidad y se agrega ponderado por carga**, igual que la serie
+   * real. Hacerlo sobre la temperatura ya promediada del nivel —que es lo que haria el
+   * frontend con `pronostico`— subestima entre 9% y 24%: medido sobre 29 dias de una UN,
+   * −9,1% partiendo de la media y −23,6% partiendo de `(Tmax+Tmin)/2`. Es el mismo
+   * Jensen que gobierna el resto del diseño.
+   */
+  pronosticoGradosDia: z.array(PuntoGradosDiaPronosticoSchema).optional(),
 
   // Clima
   climaActual: ClimaResumenSchema.optional(), // punto horario mas cercano a ahora, promediado al nivel


### PR DESCRIPTION
Extiende la curva de grados-día hacia adelante con los próximos ~8 días. Primer PR de la cadena.

## Qué agrega

`IResumenOperativoNivel.pronosticoGradosDia` — nuevo `IPuntoGradosDiaPronostico` con `fecha`, `gradosDia` (ya resuelto a la base vigente) e `integracionHoraria`.

## Dos decisiones, las dos medidas

**Va aparte de `serie` y no entra en `gradosDiaAcumulado` ni en `desvioClimaticoPct`.** Un desvío que mezcla medición con pronóstico deja de ser una medición, y es el número con el que se decide.

**Se calcula por Localidad y se agrega ponderado**, igual que la serie real — no en el frontend sobre el `pronostico` que ya recibe. Medido sobre 29 días de una UN:

```
HDD desde la T media ya agregada del nivel     -9,1%   (p10 -2,17 GD)
HDD desde (Tmax+Tmin)/2 del nivel             -23,6%   (p10 -3,84 GD)
```

Es el mismo Jensen que gobierna el resto del diseño: promediar temperaturas de una zona heterogénea y recién ahí calcular el grado-día subestima sistemáticamente.

## Por qué la bandera de método

El pronóstico horario cubre ~48 h y permite integración horaria; de ahí en adelante sólo hay máxima y mínima, y `(Tmax+Tmin)/2` subestima **−2,5%** (medido sobre 790 pares Localidad-día con las 24 h reales).

A partir del día 3 ese sesgo queda tapado por la incertidumbre del pronóstico en sí — ±2-3 °C son ±2-3 grados-día, un orden de magnitud más. Pero los dos tramos no se midieron igual, y quien lea el dato tiene derecho a saberlo.

## Costo

Cero requests: el pronóstico ya se ingiere y ya se lee en `/resumen`.

## Verificación

```
npm run build                                        ✅
npm run gen:json-schema --verbose                    ✅ ok=447 error=0
npx madge --circular --extensions js dist/interfaces  ✅ 0 ciclos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)