### PR TITLE
feat(resumen): la normal también en los días de pronóstico

### DIFF
--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -112,6 +112,16 @@ export const PuntoGradosDiaPronosticoSchema = z.object({
    * los dos tramos no se midieron igual.
    */
   integracionHoraria: z.boolean().optional(),
+
+  /**
+   * Normal 1991-2020 de ese dia del año, misma base.
+   *
+   * Viaja tambien en los dias futuros porque la normal **no es un dato del dia**: es la
+   * climatologia del dia del AÑO, y existe para el 12 de agosto de cualquier año, haya
+   * pasado o no. Sin ella el pronostico queda a medias — "vienen 18 grados-dia" no dice
+   * si es mucho o poco—, que es justamente la lectura que se busca al mirar adelante.
+   */
+  gradosDiaNormal: z.number().optional(),
 });
 export type IPuntoGradosDiaPronostico = z.infer<
   typeof PuntoGradosDiaPronosticoSchema


### PR DESCRIPTION
Segundo PR de la cadena, después de `gas-api-clima` **#18**.

`IPuntoGradosDiaPronostico` suma `gradosDiaNormal`.

## Por qué

La normal **no es un dato del día**: es la climatología 1991-2020 de ese día del año, y existe para el 12 de agosto de cualquier año, haya pasado o no.

Sin ella el pronóstico queda a medias — *"vienen 18 grados-día"* no dice si es mucho o poco, que es justamente la lectura que se busca al mirar hacia adelante.

## Verificación

```
npm run build                                        ✅
npm run gen:json-schema --verbose                    ✅ ok=447 error=0
npx madge --circular --extensions js dist/interfaces  ✅ 0 ciclos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)