### PR TITLE
refactor(canonico): categoriaTarifaria -> segmentoUsuario y fuera el eje económico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,44 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-10 - `categoriaTarifaria` -> `segmentoUsuario`, y fuera el eje económico
+
+**Decisión de alcance**: la plataforma **no hace facturación ni valorización**, y en
+principio no va a hacerlo. Todo lo que se había modelado como gancho económico era
+especulativo — sin productor y sin plan de tenerlo — así que se saca. Vale la regla de
+siempre: no hay campos en este paquete sin alguien que los escriba.
+
+**Sacado** de `canal-descriptor.ts` y del catálogo:
+
+- `DimensionEconomica` y `ICanalDescriptor.valorEconomicoDependeDe`, más los cinco usos
+  en los canales NME.
+- `neteable()` **se simplifica y se endurece**: antes consultaba
+  `valorEconomicoDependeDe` para permitir excepciones; ahora **sentidos opuestos o
+  bandas distintas nunca se netean**, y no hay forma de declarar un opt-in.
+
+**La regla sobrevive, cambia el motivo.** No netear `whImportada` con `whExportada` no
+se justificaba por el precio: se justifica porque **cuánto se inyectó** es el dato que
+determina el alivio de carga del transformador de la zona y si se cruzó el umbral por
+encima del cual el flujo se invierte. Eso es operación, y sí está en alcance. Sumarlas
+sigue permitido (energía que cruzó el medidor es una magnitud real); restarlas, no.
+
+**Renombrado**: `IClasificacionPunto.categoriaTarifaria` -> **`segmentoUsuario`**.
+
+El eje sigue sirviendo —comparar un comercio con un comercio y no con un yacimiento, que
+es justamente lo que hoy produce promedios sin significado— pero eso es **segmentación**,
+no categoría de tarifa. Se renombra ahora porque no tiene ningún consumidor: en tres
+fases más habría sido un bump en 34 repos.
+
+Efecto secundario útil: **deja de depender del cuadro tarifario de ENARGAS**. Los ~247
+puntos del padrón cuyo nombre no da ninguna pista se pueden segmentar por bandas de
+consumo propias, sin pretender que sean las oficiales. Ese documento pasa de bloqueante
+a innecesario, igual que el marco de generación distribuida.
+
+`tou` se mantiene (perfilar demanda por franja horaria es operativo) pero se le quita la
+lectura tarifaria: las bandas suman al total, y mezclar una banda con el total es doble
+conteo — eso ya lo cubre `particion`.
+
+
 ### 2026-08-10 - Modelo canónico multi-vertical: descriptor de canal, clasificación y zona de balance
 
 Fase F1 de `/PLAN-MODELO-CANONICO-MULTIVERTICAL.md`. **Todo aditivo, todo opcional, sin

--- a/src/interfaces/entidades/canal-descriptor.ts
+++ b/src/interfaces/entidades/canal-descriptor.ts
@@ -76,9 +76,8 @@ export type QuantityKind =
  * - `extremoIntervalo`: **el extremo alcanzado DENTRO del intervalo**, no un
  *   valor puntual ni un acumulado. Se agrega con `max` (o `min`), nunca con
  *   `sum`. Es el caso de la demanda máxima del medidor eléctrico —
- *   `demandaMaxImportadaW`, `demandaMaxExportadaT2W` —, que además es **la
- *   variable de facturación** de electricidad. Este valor no existía en el plan
- *   original; se agregó en la revisión multi-vertical.
+ *   `demandaMaxImportadaW`, `demandaMaxExportadaT2W` —. Este valor no existía en
+ *   el plan original; se agregó en la revisión multi-vertical.
  * - `none`: no aplica (flags, textos).
  */
 export type Accumulation =
@@ -128,10 +127,14 @@ export type Naturaleza =
  * Sentido del flujo. **Es parte de la IDENTIDAD del canal, no un atributo.**
  *
  * `whImportada` y `whExportada` son DOS canales, no uno con signo: tienen todos
- * los demás ejes idénticos y sin embargo no son neteables, porque la
- * distribuidora paga la energía inyectada a su precio de compra y la vende a
- * tarifa de usuario. 100 kWh netos pueden venir de 100 importados o de 600
- * importados y 500 exportados, con facturas completamente distintas.
+ * los demás ejes idénticos y sin embargo **no son neteables**. 100 kWh netos
+ * pueden venir de 100 importados o de 600 importados y 500 exportados, y el
+ * operador necesita distinguirlos: cuánto se **inyectó** es el dato que determina
+ * el alivio de carga del transformador de la zona y si se cruzó el umbral por
+ * encima del cual el flujo se invierte. Netear lo destruye.
+ *
+ * (La plataforma **no** hace facturación ni valorización, así que el motivo no es
+ * el precio: es operativo.)
  *
  * `neto` describe un canal que YA viene neteado por el productor (p. ej.
  * `IReporteSML.consumo`, neto de flujo inverso). Se declara para poder marcarlo
@@ -157,22 +160,14 @@ export type MeasuringPeriod =
   | "na";
 
 /**
- * Banda tarifaria (CIM `tou`). En electricidad las 18 métricas del protocolo son
- * 6 bases × 3 tarifas.
+ * Banda horaria (CIM `tou`). En electricidad las 18 métricas del protocolo son
+ * 6 bases × 3 bandas.
  *
- * Asimetría que hay que respetar: las bandas **se suman** para lo físico
- * (T1+T2+T3 = total) y **no se agregan** para lo económico, porque cada una
- * tiene precio distinto.
+ * Sirve para **perfilar la demanda por franja horaria**, que es un uso operativo.
+ * Las bandas suman al total (T1+T2+T3 = total), así que mezclar una banda con el
+ * total es doble conteo — eso lo cubre `particion`.
  */
 export type Tou = "total" | "T1" | "T2" | "T3" | "na";
-
-/**
- * De qué depende el valor económico del canal. **Gancho declarativo**: la
- * entidad de precio/tarifa no existe todavía y no es parte de este incremento,
- * pero el canal tiene que poder decirlo para que la primera liquidación no se
- * escriba a mano dentro de un servicio.
- */
-export type DimensionEconomica = "direccion" | "banda" | "categoriaUsuario";
 
 /** Referencia de la presión. Un tag reportando −1,01325 bar es un 0 absoluto. */
 export type ReferenciaPresion = "manometrica" | "absoluta" | "desconocida";
@@ -222,7 +217,7 @@ export interface IParticion {
   /** `CanalRef` del canal total del que este canal es una parte. */
   esParteDe: string;
   /**
-   * `true` si las partes suman exactamente el total (bandas tarifarias).
+   * `true` si las partes suman exactamente el total (bandas horarias).
    * `false` si son vistas alternativas del mismo hecho y **no** se suman entre
    * sí (Vm vs Vb).
    */
@@ -285,8 +280,6 @@ export interface ICanalDescriptor {
   estado: EstadoCanal;
   /** `CanalRef` del canal canónico, cuando este es un alias (kWh vs Wh). */
   aliasDe?: string;
-  /** Gancho económico: no hay entidad de precio todavía. */
-  valorEconomicoDependeDe?: DimensionEconomica[];
   descripcion?: string;
 }
 
@@ -353,25 +346,23 @@ export function sumable(a: ICanalDescriptor, b: ICanalDescriptor): boolean {
 }
 
 /**
- * ¿Se pueden **netear** (restar un sentido del otro) dos canales?
+ * ¿Se pueden **netear** (restar uno del otro) dos canales?
  *
  * Estrictamente más fuerte que `sumable`: dos canales pueden ser físicamente
- * sumables y económicamente no-neteables. Netear importada con exportada
- * destruye información de forma irreversible cuando los precios difieren.
+ * sumables y no-neteables. **Sentidos opuestos o bandas distintas nunca se
+ * netean**, sin excepción declarable.
+ *
+ * El caso que lo motiva: `whImportada` y `whExportada` tienen todos los demás
+ * ejes idénticos, así que `sumable` los acepta —sumarlas da "energía que cruzó el
+ * medidor", que es una magnitud real— pero **restarlas borra cuánto se inyectó**,
+ * que es el dato con el que se evalúa la carga del transformador de la zona.
+ *
+ * El neto se puede seguir calculando: lo que esta función impide es hacerlo **sin
+ * conservar los dos sentidos por separado**.
  */
 export function neteable(a: ICanalDescriptor, b: ICanalDescriptor): boolean {
   if (!sumable(a, b)) return false;
-  if (a.flowDirection !== b.flowDirection) {
-    // Sentidos distintos: sólo si ninguno declara dependencia económica de la
-    // dirección (es decir, si la valorización es simétrica).
-    const dependeA = a.valorEconomicoDependeDe?.includes("direccion") ?? false;
-    const dependeB = b.valorEconomicoDependeDe?.includes("direccion") ?? false;
-    if (dependeA || dependeB) return false;
-  }
-  if (a.tou !== b.tou) {
-    const dependeA = a.valorEconomicoDependeDe?.includes("banda") ?? false;
-    const dependeB = b.valorEconomicoDependeDe?.includes("banda") ?? false;
-    if (dependeA || dependeB) return false;
-  }
+  if (a.flowDirection !== b.flowDirection) return false;
+  if (a.tou !== b.tou) return false;
   return true;
 }

--- a/src/interfaces/entidades/clasificacion-punto.ts
+++ b/src/interfaces/entidades/clasificacion-punto.ts
@@ -96,15 +96,14 @@ export type ConfianzaClasificacion = z.infer<
 >;
 
 /**
- * `tipoInstalacion`, `subrol` y `categoriaTarifaria` son `string` con catálogo
- * por commodity validado en el backend, **a propósito**, en lugar de un enum
- * unión de las tres verticales.
+ * `tipoInstalacion`, `subrol` y `segmentoUsuario` son `string` con catálogo por
+ * commodity validado en el backend, **a propósito**, en lugar de un enum unión de
+ * las tres verticales.
  *
  * Motivo: un enum que enumera `TRANSFORMADOR_MT_BT` y `ODORIZADOR` en la misma
  * lista invita a asignar el valor equivocado y el tipo no lo puede impedir. Con
  * catálogo por commodity, asignar un subrol eléctrico a un punto de gas devuelve
- * 400. El segundo motivo es práctico: el catálogo de `categoriaTarifaria` depende
- * de normativa que todavía no tenemos, y un `string` no bloquea el modelo.
+ * 400.
  *
  * Catálogos vigentes:
  * - `tipoInstalacion` gas — `ERP`, `LIMITADORA`, `ALIVIO`, `ODORIZADOR`,
@@ -118,6 +117,10 @@ export type ConfianzaClasificacion = z.infer<
  *   `ENTREGA_USUARIO`, `USUARIO_GENERADOR`, `ALMACENAMIENTO_BATERIA`.
  * - `subrol` agua — `CAPTACION`, `POTABILIZACION`, `TANQUE`, `BOMBEO`,
  *   `VALVULA_REDUCTORA`, `MACROMEDICION_DMA`, `ENTREGA_USUARIO`.
+ * - `segmentoUsuario` gas — `RESIDENCIAL`, `SERVICIO_GENERAL_P`,
+ *   `SERVICIO_GENERAL_G`, `GNC`, `SUBDISTRIBUIDOR`, `GRAN_USUARIO`, `DESCONOCIDO`.
+ * - `segmentoUsuario` electricidad — `RESIDENCIAL`, `COMERCIAL`, `INDUSTRIAL`,
+ *   `GRAN_DEMANDA`, `USUARIO_GENERADOR`, `DESCONOCIDO`.
  */
 export const ClasificacionPuntoSchema = z.object({
   /** Eje A — activo físico presente en el sitio. Catálogo por commodity. */
@@ -145,8 +148,20 @@ export const ClasificacionPuntoSchema = z.object({
   /** Eje C — nivel de red. */
   nivelRed: NivelRedSchema.optional(),
 
-  /** Eje D — categoría tarifaria. Catálogo pendiente de normativa. */
-  categoriaTarifaria: z.string().optional(),
+  /**
+   * Eje D — **segmento de usuario**: residencial, comercio, industria, GNC,
+   * subdistribuidor, usuario-generador. Catálogo por commodity.
+   *
+   * Se llama segmento y **no** "categoría tarifaria" porque la plataforma no hace
+   * facturación ni valorización: sirve para **comparar lo comparable** (un
+   * comercio con un comercio y no con un yacimiento), que es lo que hoy produce
+   * promedios sin significado.
+   *
+   * Consecuencia práctica: no depende del cuadro tarifario de ENARGAS. Los puntos
+   * cuyo nombre no da ninguna pista se pueden segmentar por **bandas de consumo
+   * propias**, sin pretender que sean las oficiales.
+   */
+  segmentoUsuario: z.string().optional(),
 
   /**
    * Clase de trazado NAG-100 §5 (1..4), por cantidad de unidades de vivienda en

--- a/src/interfaces/entidades/perfil-lectura.ts
+++ b/src/interfaces/entidades/perfil-lectura.ts
@@ -373,9 +373,11 @@ const PERFIL_NUC_CORRECTORA: IPerfilLectura = {
  *
  * Los tres puntos que hacen falta acá y en ningún otro perfil:
  * - `whImportada` y `whExportada` **no son neteables**: mismo todo, distinto
- *   sentido, y la distribuidora paga la inyección a su precio de compra.
- * - `demandaMax*W` es `extremoIntervalo`: se agrega con `max`, y **es la variable
- *   de facturación**.
+ *   sentido. Sumarlas es legítimo (energía que cruzó el medidor); restarlas borra
+ *   cuánto se inyectó, que es el dato operativo.
+ * - `demandaMax*W` es `extremoIntervalo`: se agrega con `max`, nunca con `sum`.
+ *   Es el pico de carga del intervalo, y contra el límite del activo es lo que
+ *   define si hay margen.
  * - `kwh*` son alias de `wh*`: elegir mal es un factor 1000.
  */
 const PERFIL_NME: IPerfilLectura = {
@@ -403,7 +405,6 @@ const PERFIL_NME: IPerfilLectura = {
       origen: "calculado-en-backend",
       divisionRequerida: "Medidores Eléctricos",
       estado: "prod",
-      valorEconomicoDependeDe: ["direccion", "banda", "categoriaUsuario"],
       descripcion: "OBIS 1.8.0 — delta de la hora",
     },
     whExportada: {
@@ -425,9 +426,8 @@ const PERFIL_NME: IPerfilLectura = {
       origen: "calculado-en-backend",
       divisionRequerida: "Medidores Eléctricos",
       estado: "prod",
-      valorEconomicoDependeDe: ["direccion", "banda", "categoriaUsuario"],
       descripcion:
-        "OBIS 2.8.0 — inyección del usuario-generador. Se paga a precio de compra, no a tarifa",
+        "OBIS 2.8.0 — inyección del usuario-generador. NO netear con la importada: cuánto se inyectó determina el alivio de carga del transformador de la zona",
     },
     whImportadaAcum: {
       dominio: "proceso",
@@ -513,9 +513,8 @@ const PERFIL_NME: IPerfilLectura = {
       origen: "medido-por-equipo",
       divisionRequerida: "Medidores Eléctricos",
       estado: "prod",
-      valorEconomicoDependeDe: ["direccion", "banda", "categoriaUsuario"],
       descripcion:
-        "OBIS 1.6.0 — snapshot al cierre de la hora. Variable de facturación: se agrega con max, nunca sum",
+        "OBIS 1.6.0 — snapshot al cierre de la hora. Extremo del intervalo: se agrega con max, nunca sum",
     },
     demandaMaxExportadaW: {
       dominio: "proceso",
@@ -535,7 +534,6 @@ const PERFIL_NME: IPerfilLectura = {
       origen: "medido-por-equipo",
       divisionRequerida: "Medidores Eléctricos",
       estado: "prod",
-      valorEconomicoDependeDe: ["direccion", "banda", "categoriaUsuario"],
       descripcion:
         "OBIS 2.6.0 — pico de inyección. Con generación distribuida el límite del activo es bidireccional",
     },
@@ -553,8 +551,8 @@ const PERFIL_NME: IPerfilLectura = {
       rol: "medida",
       naturaleza: "calculado",
       agregableEntreDispositivos: false,
-      // Las bandas suman al total para lo FÍSICO. Para lo económico no se
-      // agregan, porque cada una tiene precio distinto.
+      // Las bandas suman al total, así que mezclar una banda CON el total es
+      // doble conteo. Sirven para perfilar demanda por franja horaria.
       particion: {
         esParteDe: "registromedidorelectricos/NME#whImportada",
         sumanAlTotal: true,
@@ -563,8 +561,7 @@ const PERFIL_NME: IPerfilLectura = {
       origen: "calculado-en-backend",
       divisionRequerida: "Medidores Eléctricos",
       estado: "prod",
-      valorEconomicoDependeDe: ["direccion", "banda", "categoriaUsuario"],
-      descripcion: "OBIS 1.8.0.1 — banda tarifaria 1",
+      descripcion: "OBIS 1.8.0.1 — banda horaria 1",
     },
   },
 };

--- a/test/predicados.test.mjs
+++ b/test/predicados.test.mjs
@@ -31,9 +31,10 @@ const NME = CATALOGO_CANALES.find((p) => p.clave === "NME").campos;
 
 // ── Caso 1 — energía importada vs exportada ────────────────────────────────
 // Tienen TODOS los ejes idénticos salvo el sentido. Son físicamente sumables
-// (energía que cruzó el medidor) y NO neteables: la distribuidora paga la
-// inyección a su precio de compra y la vende a tarifa, así que restar un sentido
-// del otro destruye la información económica de forma irreversible.
+// (energía que cruzó el medidor) y NO neteables: restar un sentido del otro borra
+// cuánto se inyectó, que es el dato con el que se evalúa el alivio de carga del
+// transformador de la zona. El motivo es operativo, no de facturación: la
+// plataforma no valoriza.
 test("1. whImportada y whExportada: sumables, NO neteables", () => {
   assert.equal(
     sumable(NME.whImportada, NME.whExportada),
@@ -43,8 +44,23 @@ test("1. whImportada y whExportada: sumables, NO neteables", () => {
   assert.equal(
     neteable(NME.whImportada, NME.whExportada),
     false,
-    "netear importada con exportada destruye la asimetría de precio",
+    "netear importada con exportada borra la inyección",
   );
+});
+
+// Sentidos opuestos NO se netean, y no hay forma de declarar una excepción: el
+// predicado no consulta ningún campo que un perfil pueda usar para opt-in.
+test("1b. la prohibición de netear sentidos opuestos no es declarable", () => {
+  const conSentidoInvertido = { ...NME.whImportada, flowDirection: "saliente" };
+  assert.equal(neteable(NME.whImportada, conSentidoInvertido), false);
+  // Mismo sentido y misma banda: netear es sumar, y eso sí se permite.
+  assert.equal(neteable(NME.whImportada, { ...NME.whImportada }), true);
+});
+
+// Bandas distintas tampoco: T1 contra T2 no se restan.
+test("1c. bandas distintas no se netean", () => {
+  const t2 = { ...NME.whImportadaT1, tou: "T2" };
+  assert.equal(neteable(NME.whImportadaT1, t2), false);
 });
 
 // ── Caso 2 — volumen corregido vs sin corregir ─────────────────────────────
@@ -93,7 +109,7 @@ test("5. una banda tarifaria no se suma con su total (doble conteo)", () => {
   assert.equal(
     NME.whImportadaT1.particion.sumanAlTotal,
     true,
-    "las bandas SÍ suman al total para lo físico; lo que no se puede es mezclarlas con el total",
+    "las bandas SÍ suman al total; lo que no se puede es mezclar una banda con el total",
   );
 });
 


### PR DESCRIPTION
Sigue una **decisión de alcance**: la plataforma no hace —ni en principio va a hacer— facturación ni valorización. Todo lo que había modelado como gancho económico era especulativo: sin productor y sin plan de tenerlo. Vale la regla de siempre para este paquete: **no hay campos sin alguien que los escriba**.

Va sobre F1 (`13a7e10`), y **antes** del PR de servicio que lo consume ([gas-datos #164](https://github.com/Horatech/gas-datos/pull/164), abierto, que se actualiza después de mergear esto).

## Sacado

- `DimensionEconomica` y `ICanalDescriptor.valorEconomicoDependeDe`, más los cinco usos en los canales NME del catálogo.
- Toda la lectura tarifaria de los comentarios (`tou`, demanda máxima, `particion`).

## `neteable()` se simplifica **y se endurece**

Antes consultaba `valorEconomicoDependeDe` para permitir excepciones. Ahora:

```ts
export function neteable(a, b) {
  if (!sumable(a, b)) return false;
  if (a.flowDirection !== b.flowDirection) return false;
  if (a.tou !== b.tou) return false;
  return true;
}
```

**Sentidos opuestos o bandas distintas nunca se netean, y no hay forma de declarar un opt-in.** Menos código y una garantía más fuerte.

## La regla sobrevive; lo que cambia es el motivo

No netear `whImportada` con `whExportada` no se justificaba por el precio. Se justifica porque **cuánto se inyectó** es el dato que determina el alivio de carga del transformador de la zona y si se cruzó el umbral por encima del cual el flujo se invierte. Eso es operación de red, y sí está en alcance.

Sumarlas sigue permitido —"energía que cruzó el medidor" es una magnitud real—; restarlas, no. Los comentarios del descriptor y del catálogo quedaron reescritos con esa justificación, para que nadie lea el código en seis meses y crea que la regla existía por un motivo que ya no aplica.

## `categoriaTarifaria` → `segmentoUsuario`

El eje sigue siendo necesario: es lo que permite comparar un comercio con un comercio y no con un yacimiento, que es exactamente lo que hoy produce el promedio de 39.083 m³/día contra una mediana de 1.621. Pero eso es **segmentación de usuario**, no categoría de tarifa, y el nombre estaba mintiendo.

**Se renombra ahora porque no tiene ningún consumidor.** En tres fases más es un bump en 34 repos.

### Efecto secundario: desbloquea ~247 puntos

`segmentoUsuario` **deja de depender del cuadro tarifario de ENARGAS**. Los puntos del padrón cuyo nombre no da ninguna pista —comercios, instituciones, hoteles, pequeña industria: unos 250, el 5,5%— se pueden segmentar por **bandas de consumo propias**, sin pretender que sean las oficiales.

Dos documentos que estaban anotados como faltantes bloqueantes pasan a innecesarios:

| Documento | Antes | Ahora |
|---|---|---|
| Cuadro tarifario / Reglamento de Servicio (ENARGAS) | bloqueaba el eje D y la clasificación por consumo | **no hace falta** |
| Marco de generación distribuida (Ley 27.424) | bloqueaba la valorización de la inyección | **no aplica** |

## `tou` se mantiene, con otra lectura

Perfilar demanda por franja horaria es un uso operativo legítimo, y las 18 métricas ya vienen así del protocolo NME. Lo que se le quita es el framing de facturación: las bandas suman al total, y mezclar una banda con el total es doble conteo — eso ya lo cubre `particion`.

## Verificación

```
npm run build                                          ✔
node -e "require('./dist/index.js')"                   ✔ 480 exports, sin DimensionEconomica
npm run gen:json-schema -- --verbose                   ✔ ok=468 error=0
npx madge --circular --extensions js dist/interfaces   ✔ 0 ciclos
npm test                                               ✔ 17/17
```

Dos tests nuevos: que la prohibición de netear sentidos opuestos **no sea declarable** (ningún campo permite el opt-in) y que bandas distintas tampoco se neteen.

El JSON Schema de `ClasificacionPuntoSchema` ya no menciona `categoriaTarifaria`.

## Después de mergear

Push a la rama de **gas-datos #164** (abierto): `npm run modelos` + renombrar `CATEGORIAS_TARIFARIAS` → `SEGMENTOS_USUARIO` en los catálogos, la validación y sus tests, y reescribir el aviso de "provisorio, falta ENARGAS" — que ya no aplica.

Y actualizar la documentación viva: el eje económico sale del plan y del análisis multi-vertical, y los dos faltantes normativos salen de la tabla de `docs/12-normativa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
