### PR TITLE
fix(canonico): commodity como campo propio de IClasificacionPunto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,25 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-10 - `IClasificacionPunto.commodity` como campo propio
+
+Bug de diseño encontrado al implementar el clasificador (F3): el `commodity` se
+derivaba de `nivelRed.commodity`, y los tres ejes de catálogo (`tipoInstalacion`,
+`subrol`, `segmentoUsuario`) se validan contra el catálogo de ese servicio. Pero
+`nivelRed` sale de la **presión medida**, y hay dato de presión para **1.228 de 4.473**
+puntos del padrón: una correctora con subrol conocido y sin presión **habría sido
+rechazada al escribir**.
+
+`commodity` pasa a ser campo propio y opcional. Cuando además hay `nivelRed`, los dos
+tienen que coincidir (lo valida el backend). Es lo correcto de todas formas: el servicio
+de un punto no es una propiedad de su nivel de red.
+
+`mismoGrupoDeAgregacion()` ahora compara `commodity` primero (con fallback a
+`nivelRed.commodity`) y **sigue exigiendo nivel de red en los dos**: sin nivel no se
+puede afirmar que dos puntos estén en el mismo, y agregar entre niveles distintos es
+justo lo que hay que impedir.
+
+
 ### 2026-08-10 - `categoriaTarifaria` -> `segmentoUsuario`, y fuera el eje económico
 
 **Decisión de alcance**: la plataforma **no hace facturación ni valorización**, y en

--- a/src/interfaces/entidades/clasificacion-punto.ts
+++ b/src/interfaces/entidades/clasificacion-punto.ts
@@ -123,6 +123,20 @@ export type ConfianzaClasificacion = z.infer<
  *   `GRAN_DEMANDA`, `USUARIO_GENERADOR`, `DESCONOCIDO`.
  */
 export const ClasificacionPuntoSchema = z.object({
+  /**
+   * Servicio del punto. **Campo propio, no derivado de `nivelRed`.**
+   *
+   * Los tres ejes de catálogo (`tipoInstalacion`, `subrol`, `segmentoUsuario`) se
+   * validan contra el catálogo de ESTE servicio, así que hace falta saberlo para
+   * poder escribirlos. Derivarlo de `nivelRed.commodity` no alcanza: el nivel de
+   * red sale de la presión medida, y hay dato de presión para menos de un tercio
+   * del padrón — un punto con subrol conocido y sin presión no se podría clasificar.
+   *
+   * Además es lo correcto: el servicio de un punto no es una propiedad de su nivel
+   * de red. Cuando ambos están presentes tienen que coincidir (lo valida el backend).
+   */
+  commodity: CommoditySchema.optional(),
+
   /** Eje A — activo físico presente en el sitio. Catálogo por commodity. */
   tipoInstalacion: z.string().optional(),
 
@@ -199,8 +213,13 @@ export function mismoGrupoDeAgregacion(
   b: IClasificacionPunto | undefined,
 ): boolean {
   if (!a || !b) return false;
+  const commodityA = a.commodity ?? a.nivelRed?.commodity;
+  const commodityB = b.commodity ?? b.nivelRed?.commodity;
+  if (!commodityA || !commodityB) return false;
+  if (commodityA !== commodityB) return false;
+  // Sin nivel de red no se puede afirmar que dos puntos estén en el mismo nivel,
+  // y agregar entre niveles distintos es justamente lo que hay que impedir.
   if (!a.nivelRed || !b.nivelRed) return false;
-  if (a.nivelRed.commodity !== b.nivelRed.commodity) return false;
   if (a.nivelRed.codigo !== b.nivelRed.codigo) return false;
   const rolesA = a.rolesRed ?? [];
   const rolesB = b.rolesRed ?? [];

--- a/test/predicados.test.mjs
+++ b/test/predicados.test.mjs
@@ -118,20 +118,47 @@ test("5. una banda tarifaria no se suma con su total (doble conteo)", () => {
 // 39.083 m³/día contra una mediana de 1.621.
 test("6. dos puntos con rol de red distinto no son agregables", () => {
   const cityGate = {
+    commodity: "gas",
     rolesRed: ["FUENTE"],
     nivelRed: { commodity: "gas", codigo: "ALTA", orden: 2 },
   };
   const comercio = {
+    commodity: "gas",
     rolesRed: ["CONSUMO"],
     nivelRed: { commodity: "gas", codigo: "ALTA", orden: 2 },
   };
   assert.equal(mismoGrupoDeAgregacion(cityGate, comercio), false);
 
   const otroComercio = {
+    commodity: "gas",
     rolesRed: ["CONSUMO"],
     nivelRed: { commodity: "gas", codigo: "ALTA", orden: 2 },
   };
   assert.equal(mismoGrupoDeAgregacion(comercio, otroComercio), true);
+});
+
+// Nunca se agrega entre servicios, ni siquiera con el mismo rol y el mismo código
+// de nivel: "MEDIA" de gas y "MEDIA" de otro servicio no son el mismo nivel.
+test("6b. servicios distintos nunca son agregables", () => {
+  const gas = {
+    commodity: "gas",
+    rolesRed: ["CONSUMO"],
+    nivelRed: { commodity: "gas", codigo: "MEDIA", orden: 3 },
+  };
+  const agua = {
+    commodity: "agua",
+    rolesRed: ["CONSUMO"],
+    nivelRed: { commodity: "agua", codigo: "DMA", orden: 3 },
+  };
+  assert.equal(mismoGrupoDeAgregacion(gas, agua), false);
+});
+
+// El commodity es campo propio: un punto clasificado SIN nivel de red (porque no
+// hay presión medida) sigue sin autorizar agregación, pero el servicio se conoce.
+test("6c. commodity sin nivelRed no autoriza agregar", () => {
+  const a = { commodity: "gas", rolesRed: ["CONSUMO"] };
+  const b = { commodity: "gas", rolesRed: ["CONSUMO"] };
+  assert.equal(mismoGrupoDeAgregacion(a, b), false);
 });
 
 // ── Retrocompatibilidad ────────────────────────────────────────────────────


### PR DESCRIPTION
Bug de diseño **encontrado al implementar el clasificador (F3)**. Es chico y bloquea F3, así que va aparte.

## El problema

En F1/F2 el `commodity` de una clasificación se derivaba de `nivelRed.commodity`, y los tres ejes de catálogo —`tipoInstalacion`, `subrol`, `segmentoUsuario`— se validan contra el catálogo de **ese** servicio (`gas-datos`, `auxiliares/clasificacion/validar.ts`).

Pero `nivelRed` sale de la **presión medida**, y medí cuánta hay: **1.228 de 4.473** puntos del padrón de Camuzzi. O sea que una correctora con `subrol` perfectamente conocido —porque su grupo dice `Industrias`— y sin dato de presión **habría sido rechazada con 400 al escribir**. El clasificador no podría escribir dos tercios de lo que sabe.

## El arreglo

`commodity` pasa a ser **campo propio y opcional** de `IClasificacionPunto`. Si además viene `nivelRed`, los dos tienen que coincidir (lo valida el backend en el PR de `gas-datos` que sigue).

Es lo correcto de todas formas: **el servicio de un punto no es una propiedad de su nivel de red**. Lo que había era un atajo que funcionaba sólo cuando había presión.

## `mismoGrupoDeAgregacion()`

Compara `commodity` primero, con fallback a `nivelRed.commodity` para lo ya escrito. Y **sigue exigiendo nivel de red en los dos puntos**: sin nivel no se puede afirmar que estén en el mismo, y agregar entre niveles distintos es justamente lo que hay que impedir. El candado no se afloja.

## Verificación

```
npm run build                                          ✔
npm run gen:json-schema -- --verbose                   ✔ ok=468 error=0
npx madge --circular --extensions js dist/interfaces   ✔ 0 ciclos
npm test                                               ✔ 19/19
```

Tres tests nuevos:
- servicios distintos nunca son agregables, ni con el mismo rol y el mismo código de nivel (`MEDIA` de gas y `DMA` de agua comparten `orden: 3` y no son el mismo nivel);
- `commodity` sin `nivelRed` **no** autoriza agregar;
- el caso 6 original sigue pasando.

## Retrocompatibilidad

Campo opcional, nada renombrado, sin migración. Los documentos ya escritos —ninguno todavía, la clasificación no tiene datos— seguirían resolviendo por el fallback.

## Después de mergear

`npm run modelos` en `gas-datos` + el PR de F3: clasificador (función pura + escritor + `dry-run`) y el ajuste de `validar.ts` para aceptar `commodity` propio y verificar la coherencia con `nivelRed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)