### PR TITLE
fix(canonico): OrigenClasificacion suma 'division'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,26 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-11 - `OrigenClasificacion` suma `'division'`
+
+Detectado leyendo el reporte del **primer dry-run desplegado en test**: 862 puntos de
+`Residencial Agua` salían atribuidos a `patron-nombre` y su `commodity` a `manual`.
+
+Las dos atribuciones eran falsas, y son justamente las que existen para poder auditar:
+
+- Esos puntos se clasifican **por su división**, con certeza, sin evaluar ningún nombre.
+- `patron-nombre` además fuerza `confianza: 'baja'` en el cálculo del clasificador, así
+  que el caso **más** seguro del padrón quedaba registrado como el menos confiable.
+- `manual` es peor: significa "lo decidió un operador", que es lo que acompaña a
+  `bloqueada` en el resto del sistema. Atribuirle eso a un cálculo automático es mentir
+  en el campo que existe para no mentir.
+
+El valor faltaba y su ausencia obligaba a elegir entre dos mentiras. En el padrón de
+Camuzzi afectaba a los 1.279 puntos residenciales más el `commodity` de los 4.473.
+
+**Nada escrito para corregir**: todas las corridas fueron en dry-run.
+
+
 ### 2026-08-10 - `IClasificacionPunto.commodity` como campo propio
 
 Bug de diseño encontrado al implementar el clasificador (F3): el `commodity` se

--- a/src/interfaces/entidades/clasificacion-punto.ts
+++ b/src/interfaces/entidades/clasificacion-punto.ts
@@ -78,6 +78,19 @@ export const OrigenClasificacionSchema = z.enum([
   "tag-opc",
   /** Import del listado del cliente. Única fuente posible de la medición fiscal. */
   "declaracion-cliente",
+  /**
+   * Derivado de la `division` del punto. **Confianza alta**: la división siempre
+   * está y no admite interpretación — un punto de `Residencial Agua` es agua y es
+   * consumo de un usuario, sin ambigüedad.
+   *
+   * Existe porque su ausencia obligaba a mentir. El clasificador atribuía lo
+   * derivado de la división a `patron-nombre` (que además fuerza `confianza: 'baja'`)
+   * y el `commodity` a `manual` — y `manual` significa "lo decidió un operador", que
+   * es exactamente lo que no era. Se detectó leyendo el reporte del primer dry-run
+   * en test: 862 puntos residenciales atribuidos a un patrón de nombre que nunca
+   * se evaluó.
+   */
+  "division",
   /** Los `grupos` que ya venían cargando los operadores. */
   "grupo-operador",
   "patron-nombre",


### PR DESCRIPTION
**Detectado leyendo el reporte del primer dry-run desplegado en test.** El clasificador (F3) ya está corriendo en `gas-datos-test` y su reporte por fuente mostró esto para AYSAM:

```json
"porFuente": { "manual": 862, "patron-nombre": 4310 }
```

Esos 862 son puntos de `Residencial Agua`. **Las dos atribuciones son falsas**, y son justo las que existen para poder auditar:

| Atribución | Qué dice | Qué era en realidad |
|---|---|---|
| `patron-nombre` | se clasificó por parecido de nombre | se derivó **de la división**, sin evaluar ningún nombre |
| `manual` | **lo decidió un operador** | lo calculó el job |

Y hay un efecto en cascada: `patron-nombre` fuerza **`confianza: 'baja'`** en el cálculo del clasificador. O sea que el caso **más seguro de todo el padrón** —un punto de `Residencial Agua` es agua y es consumo de un usuario final, sin ambigüedad posible— quedaba registrado como el menos confiable.

`manual` es la peor de las dos: en el resto del sistema es el valor que acompaña a `bloqueada`, o sea "no lo toques, lo puso una persona".

## El arreglo

El valor `'division'` faltaba, y su ausencia obligaba a elegir entre dos mentiras. Se agrega con la documentación de por qué es **confianza alta**: la división siempre está y no admite interpretación.

## Alcance del defecto

En el padrón de Camuzzi habría afectado a los **1.279 puntos residenciales** más el `commodity` de los **4.473**.

**No hay nada escrito que corregir**: todas las corridas fueron en `dryRun: true`. El default del endpoint y del cron es no escribir, y eso es exactamente lo que permitió encontrar esto leyendo un reporte en lugar de una base de datos.

## Verificación

```
npm run build                                          ✔
npm run gen:json-schema -- --verbose                   ✔ ok=468 error=0
npx madge --circular --extensions js dist/interfaces   ✔ 0 ciclos
npm test                                               ✔ 19/19
```

## Después de mergear

`npm run modelos` en `gas-datos` + el ajuste del clasificador:

- atribuir a `'division'` lo que sale de la división (el `commodity` y el bloque residencial completo);
- corregir el cálculo de `confianza` para que `'division'`, `'tag-opc'` y `'declaracion-cliente'` cuenten como **alta**;
- sumar `'division'` a la lista de prioridad con la que se elige el `origen` del conjunto.

Y volver a desplegar a test para confirmar que el reporte deja de mentir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)