### PR TITLE
feat(clima): grados-día con sentido (calefacción y refrigeración)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,32 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-11 - Grados-día con sentido: calefacción y refrigeración
+
+La base de los grados-día **ya era paramétrica** (el rollup guarda el vector de 15 bases,
+10 a 24 °C). Lo que estaba horneado era el **sentido**: en el nombre de los campos y en el
+cálculo, `Σ max(0, base − T)` — sólo frío.
+
+Alcanza para gas, donde la demanda sube con el frío y nada más. **No alcanza para
+electricidad, cuya demanda es bimodal en temperatura**: sube con el frío y también con el
+calor. Con un solo sentido, el verano de una red eléctrica se lee como si no pasara nada.
+
+- `SentidoGradosDia` = `'calefaccion' | 'refrigeracion'`. **Ausente se lee como
+  `calefaccion`**, que es lo que son todos los datos anteriores.
+- `IResumenOperativoNivel.sentidoGradosDia` y `IResumenDesvioHijo.sentidoGradosDia`, al
+  lado de `baseHdd` y por el mismo motivo: sin él el número no se interpreta — 600
+  grados-día de calefacción y 600 de refrigeración describen estaciones opuestas.
+- `IResumenDiarioLocalidad.gradosDiaRefrigeracion` y `gradosDiaOwmRefrigeracion`: los
+  vectores diarios de CDD, contraparte de `gradosDia` y `gradosDiaOwm`.
+
+**`gradosDia` sigue siendo calefacción** y no se renombra: tiene datos escritos y el
+rename no aportaría nada que el `sentido` explícito no resuelva.
+
+**Ausente ≠ cero** en los campos nuevos. Los días anteriores a este cambio no los tienen;
+poblarlos exige recalcular la serie diaria de ERA5 (76 años de histórico), que es una
+decisión aparte.
+
+
 ### 2026-08-11 - `OrigenClasificacion` suma `'division'`
 
 Detectado leyendo el reporte del **primer dry-run desplegado en test**: 862 puntos de

--- a/src/interfaces/entidades/resumen-diario-localidad.ts
+++ b/src/interfaces/entidades/resumen-diario-localidad.ts
@@ -85,6 +85,20 @@ export const ResumenDiarioLocalidadSchema = z.object({
   gradosDiaEfectivos: z.record(z.string(), z.number()).optional(),
 
   /**
+   * Grados-día de **refrigeración** (CDD) del día, mismo indexado por base:
+   * `Σ max(0, T_h − base) / N`. Contraparte de `gradosDia`, que es de **calefacción**.
+   *
+   * Hace falta porque **la demanda eléctrica es bimodal en temperatura**: sube con el
+   * frío y también con el calor. Con un solo sentido, el verano de una red eléctrica se
+   * lee como si no pasara nada. En gas casi siempre es 0 y no molesta.
+   *
+   * Escribe la serie diaria de ERA5-Land, igual que `gradosDia`. Los días anteriores a
+   * ago 2026 no lo tienen: hay que recalcular la serie para poblarlos, y ese recálculo
+   * es una decisión aparte (76 años de histórico). Ausente ≠ cero.
+   */
+  gradosDiaRefrigeracion: z.record(z.string(), z.number()).optional(),
+
+  /**
    * Normal 1991-2020 de ESE dia del año, mismo indexado por base. Es contra esto
    * que se mide el desvio: sin la normal, un grado-dia suelto no dice nada.
    */
@@ -134,6 +148,13 @@ export const ResumenDiarioLocalidadSchema = z.object({
    * muestras el promedio no describe el dia y produciria un numero que parece un dato.
    */
   gradosDiaOwm: z.record(z.string(), z.number()).optional(),
+
+  /**
+   * Refrigeración (CDD) desde la serie horaria de OpenWeatherMap. Es a `gradosDiaOwm` lo
+   * que `gradosDiaRefrigeracion` es a `gradosDia`: el relleno de la punta mientras ERA5
+   * no publica, con el mismo gate de >= 20 horas y el mismo sesgo conocido.
+   */
+  gradosDiaOwmRefrigeracion: z.record(z.string(), z.number()).optional(),
 
   /** Temperatura efectiva: `0,5·T(d) + 0,5·T_ef(d−1)`. Inercia termica del parque. */
   temperaturaEfectiva: z.number().optional(), // °C

--- a/src/interfaces/entidades/resumen-operativo-nivel.ts
+++ b/src/interfaces/entidades/resumen-operativo-nivel.ts
@@ -15,6 +15,24 @@ export const NivelResumenSchema = z.enum([
 export type NivelResumen = z.infer<typeof NivelResumenSchema>;
 
 /** Punto de la serie diaria: consumo + temperatura (tendencia + correlacion). */
+/**
+ * Sentido de los grados-día.
+ *
+ * - `calefaccion` (HDD): `Σ max(0, base − T)`. Cuánto frío hubo. Es el que gobierna la
+ *   demanda de gas y el único que existía hasta ago 2026.
+ * - `refrigeracion` (CDD): `Σ max(0, T − base)`. Cuánto calor hubo.
+ *
+ * Hace falta porque **la demanda eléctrica es bimodal en temperatura**: sube con el frío
+ * y también con el calor. Con un solo sentido, el verano de una red eléctrica se lee como
+ * si no pasara nada.
+ *
+ * La base ya era paramétrica (el rollup guarda el vector de 15 bases); lo que estaba
+ * horneado era el sentido, en el nombre de los campos y en el cálculo. Ausente se lee
+ * como `calefaccion`, que es lo que son todos los datos anteriores a este cambio.
+ */
+export const SentidoGradosDiaSchema = z.enum(["calefaccion", "refrigeracion"]);
+export type SentidoGradosDia = z.infer<typeof SentidoGradosDiaSchema>;
+
 export const PuntoSerieResumenSchema = z.object({
   fecha: z.string(), // inicio del dia gas
   // Consumo TOTALIZADO del dia (suma de todos los medidores del nivel).
@@ -173,6 +191,15 @@ export const ResumenOperativoNivelSchema = z.object({
    */
   baseHdd: z.number().optional(),
 
+  /**
+   * Sentido con el que se resolvieron los escalares de `serie` y los acumulados.
+   *
+   * Viaja por el mismo motivo que `baseHdd`: sin él el número no se interpreta — 600
+   * grados-día de calefacción y 600 de refrigeración describen estaciones opuestas.
+   * Ausente se lee como `calefaccion`.
+   */
+  sentidoGradosDia: SentidoGradosDiaSchema.optional(),
+
   /** Suma de los grados-dia del periodo. Acumular sobre el TIEMPO si es valido. */
   gradosDiaAcumulado: z.number().optional(),
 
@@ -291,6 +318,8 @@ export const ResumenDesvioHijoSchema = z.object({
 
   /** Base en °C con la que se resolvieron los acumulados. Ver `baseHdd` del nivel. */
   baseHdd: z.number().optional(),
+  /** Sentido con el que se resolvieron. Ver `sentidoGradosDia` del nivel. */
+  sentidoGradosDia: SentidoGradosDiaSchema.optional(),
 
   gradosDiaAcumulado: z.number().optional(),
   gradosDiaNormalAcumulado: z.number().optional(),


### PR DESCRIPTION
**F2b** de `/PLAN-MODELO-CANONICO-MULTIVERTICAL.md`. Primer PR de la cadena: `modelos` va antes que los servicios.

## Qué estaba horneado, y qué no

Buena noticia primero: **la base ya era paramétrica**. El rollup guarda el vector de 15 bases (10 a 24 °C) justamente para que cambiar la base sea una decisión de lectura. Eso está bien resuelto y no se toca.

Lo que estaba horneado era el **sentido** — en el nombre de los campos y en el cálculo:

```
Σ max(0, base − T)     ← sólo frío
```

Alcanza para gas, donde la demanda sube con el frío y nada más. **No alcanza para electricidad, cuya demanda es bimodal en temperatura**: sube con el frío y también con el calor. Con un solo sentido, el verano de una red eléctrica se lee como si no pasara nada — y electricidad ya es una vertical activa, con `IRegistroMedidorElectrico` escribiendo en producción.

## Qué agrega

| Campo | Dónde | Para qué |
|---|---|---|
| `SentidoGradosDia` = `'calefaccion' \| 'refrigeracion'` | tipo nuevo | el eje que faltaba |
| `sentidoGradosDia` | `IResumenOperativoNivel`, `IResumenDesvioHijo` | al lado de `baseHdd`, y por el mismo motivo |
| `gradosDiaRefrigeracion` | `IResumenDiarioLocalidad` | vector diario de CDD desde ERA5-Land |
| `gradosDiaOwmRefrigeracion` | `IResumenDiarioLocalidad` | idem desde OpenWeatherMap (relleno de la punta) |

`sentidoGradosDia` viaja junto a `baseHdd` porque **sin él el número no se interpreta**: 600 grados-día de calefacción y 600 de refrigeración describen estaciones opuestas. Es exactamente el argumento con el que `baseHdd` ya viajaba explícita.

## Dos decisiones

**`gradosDia` sigue siendo calefacción y no se renombra.** Tiene datos escritos, y el rename no aportaría nada que el sentido explícito no resuelva. **Ausente se lee como `calefaccion`**, que es lo que son todos los datos anteriores a este cambio.

**Ausente ≠ cero** en los campos nuevos. Los días anteriores no los tienen, y poblarlos exige **recalcular la serie diaria de ERA5-Land**: 76 años de histórico. Ese recálculo es idempotente (upsert por `(clave, fecha)`) pero es una operación con costo, así que queda como decisión aparte y no como parte de este PR.

## Verificación

```
npm run build                                          ✔
npm run gen:json-schema -- --verbose                   ✔ ok=469 error=0
npx madge --circular --extensions js dist/interfaces   ✔ 0 ciclos
npm test                                               ✔ 19/19
```

## La cadena que sigue

Tres repos, en este orden:

1. **`gas-api-clima`** — `gradosDiaIntegrado()` (la función pura de `src/era5/hdd.ts`) calcula los dos sentidos; la serie diaria de ERA5 persiste el CDD.
2. **`gas-datos`** — `gradosDiaOwm()` calcula los dos; el rollup escribe ambos vectores.
3. **`gas-api-cliente`** — `hddDeBase()` resuelve por `(base, sentido)` y el DTO expone el sentido usado. **Default `calefaccion`**, así que el comportamiento actual no cambia.

**Criterio de aceptación de F2b**: el resultado de calefacción queda **bit-idéntico** al actual, y refrigeración da > 0 en verano en alguna localidad del norte del área de servicio.

Nota de alcance: sin la **normal** de refrigeración no hay `desvioClimaticoPct` para el verano. La normal sale del mismo pipeline de ERA5 y entra con el recálculo del histórico, no antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)