### PR TITLE
feat(conectividad): la recepción por gateway como entidad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,45 @@ export type TipoEntradaDigital = "CONTADOR" | "FLAG" | "ALERTA" | "EN_DESUSO";
 
 ## Cambios recientes
 
+### 2026-08-14 - La recepción por gateway como entidad (conectividad LoRaWAN)
+
+Fase F0 de `/PLAN-CONECTIVIDAD-COBERTURA-LORAWAN-V3.md`. Aditivo y opcional: publicarlo no
+cambia el comportamiento de ningún servicio.
+
+**Un uplink LoRaWAN no es "el RSSI del dispositivo": es N recepciones, una por gateway que
+lo escuchó.** Ese detalle llega hoy a `gas-entrada-lora` en `IUplink.metadatos[]`
+(gatewayID, rssi, loRaSNR, location por gateway), viaja a la API de device… y **ninguna lo
+lee**: `gas-sml`, `gas-api-ml107a`, `gas-api-euw300` y `gas-api-nme` no mencionan `rssi` en
+todo su `src/`. Por eso `IDispositivo.rssi/snr/dr/adr` **están muertos** — el único escritor
+de `rssi` en todo el sistema es `gas-api-uwm-nb`, que es NB-IoT, no LoRa. Quedan marcados
+`@deprecated` (los sigue leyendo el padrón exportado y el detalle del PM de agua, siempre
+vacíos; se limpian en F6).
+
+- Nuevo `recepcion-uplink.ts`: `GatewayRecepcionSchema`, `UltimaRecepcionSchema` (estado del
+  enlace en el último uplink, para embeber) y `RecepcionUplinkSchema` (traza histórica, la
+  colección lleva TTL).
+- `IDispositivo.ultimaRecepcion` — lo escribe `gas-entrada-lora`, único punto por donde
+  pasan todos los uplinks de los tres network servers (ChirpStack v3, v4, Orbiwise). Escribir
+  ahí evita tocar las ~8 APIs de device.
+- `TipoAlertaSchema` suma `"Gateway sin reportar"` e `IAlerta` suma `idGatewayLorawan` + el
+  virtual `gatewayLorawan`. **Es el primer tipo de alerta a nivel infraestructura**: no lleva
+  `deveui` ni punto de medición. Hasta ahora un backhaul caído sólo se veía como N puntos
+  "Sin Reportar" — los 3 gateways de ITCSA estuvieron 9 h 19 min caídos sin generar una sola
+  alerta. La abre gas-cron **con histéresis** (antecedente: 16.570 alertas por flapping).
+
+⚠️ **`distancia` se calcula contra `IGatewayLorawan.ubicacion`, NUNCA contra el `location`
+de `rxInfo`.** Los gateways hospedados reportan la ubicación estática del packet forwarder:
+los tres de ITCSA informan Chascomús estando en Mendoza, a 1.000 km. La cobertura actual
+(`gas-field-tester`) usa `rxInfo` y por eso tiene las distancias mal.
+
+`IRecepcionUplink` **no lleva virtuals de populate**: `IDispositivo`/`IPuntoMedicion` son del
+SCC y un schema real de ese lado cierra el ciclo. Lo que hace falta para mostrar la fila va
+denormalizado. `alerta.ts` sí usa el schema real de `IGatewayLorawan` (está fuera del SCC).
+Verificado: `madge --circular` sobre `dist/` da 0.
+
+⚠️ Necesita sus `@Prop()` en gas-datos (`dispositivo.model.ts` y `alerta.model.ts`): los
+schemas son estrictos y sin el `@Prop()` Mongoose descarta el valor **en silencio**.
+
 ### 2026-08-11 - Grados-día con sentido: calefacción y refrigeración
 
 La base de los grados-día **ya era paramétrica** (el rollup guarda el vector de 15 bases,

--- a/src/interfaces/entidades/alerta.ts
+++ b/src/interfaces/entidades/alerta.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { LocalidadSchema } from "./localidad";
+import { GatewayLorawanSchema } from "./gateway-lorawan";
 import { DivisionSchema } from "../tenant/usuario/permiso";
 import { ClienteSchema } from "../tenant/cliente.model";
 import { CentroOperativoSchema } from "../gas/centroOperativo/schema";
@@ -43,6 +44,11 @@ export const TipoAlertaSchema = z.enum([
   "Medidor detenido",
   "Fuga",
   "Sobrecaudal",
+  // Único tipo a nivel infraestructura, no a nivel dispositivo: el gateway
+  // LoRaWAN dejó de reportar al network server. No lleva deveui ni punto de
+  // medición, sí `idGatewayLorawan`. La abre gas-cron con histéresis (un
+  // backhaul caído se veía sólo como N puntos "Sin Reportar").
+  "Gateway sin reportar",
 ]);
 export type ITipoAlerta = z.infer<typeof TipoAlertaSchema>;
 
@@ -87,10 +93,13 @@ export const AlertaSchema = z.object({
   idMedidorElectrico: z.string().optional(),
   idScada: z.string().optional(),
   idDispositivoExternoNuc: z.string().optional(),
+  /** `_id` del GatewayLorawan, sólo en alertas de tipo "Gateway sin reportar" */
+  idGatewayLorawan: z.string().optional(),
   numeroSerieCorrectora: z.string().nullable().optional(),
   fechaCreacion: z.string().optional(),
   // Virtuals
   cliente: ClienteSchema.optional(),
+  gatewayLorawan: GatewayLorawanSchema.optional(),
   unidadNegocio: UnidadNegocioSchema.optional(),
   centroOperativo: CentroOperativoSchema.optional(),
   localidad: LocalidadSchema.optional(),
@@ -134,10 +143,12 @@ export interface IAlerta {
   idMedidorElectrico?: string;
   idScada?: string;
   idDispositivoExternoNuc?: string;
+  idGatewayLorawan?: string;
   numeroSerieCorrectora?: string | null;
   fechaCreacion?: string;
   // Virtuals
   cliente?: import("../tenant/cliente.model").ICliente;
+  gatewayLorawan?: import("./gateway-lorawan").IGatewayLorawan;
   unidadNegocio?: import("../gas/unidadNegocio/schema").IUnidadNegocio;
   centroOperativo?: import("../gas/centroOperativo/schema").ICentroOperativo;
   localidad?: import("./localidad").ILocalidad;
@@ -154,6 +165,7 @@ export interface IAlerta {
 export const CreateAlertaSchema = AlertaSchema.omit({
   _id: true,
   cliente: true,
+  gatewayLorawan: true,
   unidadNegocio: true,
   centroOperativo: true,
   localidad: true,
@@ -168,6 +180,7 @@ export const CreateAlertaSchema = AlertaSchema.omit({
 type OmitirCreate =
   | "_id"
   | "cliente"
+  | "gatewayLorawan"
   | "unidadNegocio"
   | "centroOperativo"
   | "localidad"
@@ -185,6 +198,7 @@ export const UpdateAlertaSchema = CreateAlertaSchema;
 type OmitirUpdate =
   | "_id"
   | "cliente"
+  | "gatewayLorawan"
   | "unidadNegocio"
   | "centroOperativo"
   | "localidad"

--- a/src/interfaces/entidades/dispositivo.ts
+++ b/src/interfaces/entidades/dispositivo.ts
@@ -7,6 +7,7 @@ import { ClienteSchema } from "../tenant/cliente.model";
 import { LoraServerSchema } from "../tenant/lora-server.model";
 import { LoteDispositivoSchema } from "../tenant/loteDispositivo.model";
 import { LocalidadSchema } from "./localidad";
+import { IUltimaRecepcion, UltimaRecepcionSchema } from "./recepcion-uplink";
 import type { IAlerta } from "./alerta";
 import type { IRegistro } from "./registro";
 
@@ -36,11 +37,21 @@ export const DispositivoSchema = z.object({
   // Solo con conectividad Lora
   idLoraServer: z.string().optional(),
   // Info de comunicacion
+  /** @deprecated sin escritor en LoRa: usar `ultimaRecepcion.maxSnr` */
   snr: z.number().optional(),
+  /** @deprecated sin escritor en LoRa: usar `ultimaRecepcion.maxRssi` */
   rssi: z.number().optional(),
+  /** @deprecated sin escritor: usar `ultimaRecepcion.adr` */
   adr: z.boolean().optional(),
+  /** @deprecated sin escritor: usar `ultimaRecepcion.dr` */
   dr: z.number().optional(),
   fechaUltimaComunicacion: z.string().optional(),
+  /**
+   * Estado del enlace en el último uplink recibido, con el detalle por gateway.
+   * Lo escribe gas-entrada-lora (único punto por donde pasan todos los uplinks
+   * LoRa de los tres network servers). Sólo dispositivos con conectividad LORA.
+   */
+  ultimaRecepcion: UltimaRecepcionSchema.optional(),
   // Otra info
   firmware: z.string().optional(),
   versionHardware: z.string().optional(), // Versión de hardware (ej: "v1", "v3" para NUC con/sin GPIO)
@@ -78,11 +89,16 @@ export interface IDispositivo {
   idLote?: string;
   tipoDispositivo?: TipoDispositivoGas;
   idLoraServer?: string;
+  /** @deprecated sin escritor en LoRa: usar `ultimaRecepcion.maxSnr` */
   snr?: number;
+  /** @deprecated sin escritor en LoRa: usar `ultimaRecepcion.maxRssi` */
   rssi?: number;
+  /** @deprecated sin escritor: usar `ultimaRecepcion.adr` */
   adr?: boolean;
+  /** @deprecated sin escritor: usar `ultimaRecepcion.dr` */
   dr?: number;
   fechaUltimaComunicacion?: string;
+  ultimaRecepcion?: IUltimaRecepcion;
   firmware?: string;
   versionHardware?: string;
   serieTransmisor?: string;

--- a/src/interfaces/entidades/index.ts
+++ b/src/interfaces/entidades/index.ts
@@ -63,4 +63,5 @@ export * from "./indicadores-historicos";
 export * from "./gateway-lorawan";
 export * from "./cobertura-lorawan";
 export * from "./estadistica-gateway-lorawan";
+export * from "./recepcion-uplink";
 //

--- a/src/interfaces/entidades/recepcion-uplink.ts
+++ b/src/interfaces/entidades/recepcion-uplink.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { CoordenadasSchema, GeoJSONSchema } from "../auxiliares/coordenadas";
+
+/**
+ * Recepción de un uplink por un gateway individual.
+ *
+ * Un uplink LoRaWAN no es "el RSSI del dispositivo": es una recepción por cada
+ * gateway que lo escuchó. Ese detalle llega en `IUplink.metadatos[]` a
+ * gas-entrada-lora y hasta ahora se descartaba.
+ */
+export const GatewayRecepcionSchema = z.object({
+  /** EUI64 del gateway en el network server */
+  gatewayId: z.string().optional(),
+  rssi: z.number().optional(),
+  snr: z.number().optional(),
+  /**
+   * Distancia great-circle dispositivo-gateway en metros. Se calcula contra
+   * `IGatewayLorawan.ubicacion`, NUNCA contra el `location` de `rxInfo`: los
+   * gateways hospedados reportan la ubicación estática del packet forwarder
+   * (los tres de ITCSA informan Chascomús estando en Mendoza).
+   */
+  distancia: z.number().optional(),
+});
+export type IGatewayRecepcion = z.infer<typeof GatewayRecepcionSchema>;
+
+/**
+ * Estado del enlace en el último uplink recibido. Se embebe en `IDispositivo`
+ * para que el mapa y el detalle del punto de medición lo lean sin pegarle a la
+ * colección histórica.
+ */
+export const UltimaRecepcionSchema = z.object({
+  fecha: z.string().optional(),
+  fCnt: z.number().optional(),
+  fPort: z.number().optional(),
+  /** Data rate del uplink */
+  dr: z.number().optional(),
+  /** Spreading factor derivado del data rate */
+  sf: z.number().optional(),
+  /** Frecuencia en Hz */
+  frecuencia: z.number().optional(),
+  /** Ancho de banda en Hz (de txInfo) */
+  bandwidth: z.number().optional(),
+  /** Code rate (de txInfo, ej. "4/5") */
+  codeRate: z.string().optional(),
+  adr: z.boolean().optional(),
+  /** Una entrada por gateway que escuchó el uplink */
+  gateways: z.array(GatewayRecepcionSchema).optional(),
+  /** Diversidad de recepción: cuántos gateways lo escucharon */
+  cantidadGateways: z.number().optional(),
+  /** `gatewayId` del gateway con mejor RSSI */
+  mejorGatewayId: z.string().optional(),
+  minRssi: z.number().optional(),
+  maxRssi: z.number().optional(),
+  minSnr: z.number().optional(),
+  maxSnr: z.number().optional(),
+});
+export type IUltimaRecepcion = z.infer<typeof UltimaRecepcionSchema>;
+
+/**
+ * Recepción histórica de un uplink. La escribe gas-entrada-lora en lote (mismo
+ * patrón que `ILogLora`) y la colección tiene TTL: no es el reporte del
+ * dispositivo, es la traza del enlace.
+ *
+ * Sin virtuals de populate a propósito: `IDispositivo`/`IPuntoMedicion` son
+ * parte del SCC de dispositivo y un schema real de ese lado cierra el ciclo
+ * (ver CLAUDE.md). Lo que se necesita para mostrar la fila va denormalizado.
+ */
+export const RecepcionUplinkSchema = UltimaRecepcionSchema.extend({
+  _id: z.string().optional(),
+  deveui: z.string().optional(),
+  deviceName: z.string().optional(),
+  idDispositivo: z.string().optional(),
+  idLoraServer: z.string().optional(),
+  idCliente: z.string().optional(),
+  idPuntoMedicion: z.string().optional(),
+  /** Ubicación del dispositivo/punto al momento de la recepción */
+  ubicacion: CoordenadasSchema.optional(),
+  /** Punto GeoJSON para queries geoespaciales (índice 2dsphere) */
+  geojson: GeoJSONSchema.optional(),
+});
+export type IRecepcionUplink = z.infer<typeof RecepcionUplinkSchema>;
+
+// CREATE
+export const CreateRecepcionUplinkSchema = RecepcionUplinkSchema.omit({
+  _id: true,
+});
+export type ICreateRecepcionUplink = z.infer<typeof CreateRecepcionUplinkSchema>;

--- a/src/interfaces/entidades/recepcion-uplink.ts
+++ b/src/interfaces/entidades/recepcion-uplink.ts
@@ -61,9 +61,13 @@ export type IUltimaRecepcion = z.infer<typeof UltimaRecepcionSchema>;
  * patrón que `ILogLora`) y la colección tiene TTL: no es el reporte del
  * dispositivo, es la traza del enlace.
  *
- * Sin virtuals de populate a propósito: `IDispositivo`/`IPuntoMedicion` son
- * parte del SCC de dispositivo y un schema real de ese lado cierra el ciclo
- * (ver CLAUDE.md). Lo que se necesita para mostrar la fila va denormalizado.
+ * Sin virtuals de populate a propósito: `IDispositivo` es parte del SCC de
+ * dispositivo y un schema real de ese lado cierra el ciclo (ver CLAUDE.md).
+ * Lo que se necesita para mostrar la fila va denormalizado.
+ *
+ * Tampoco lleva `idPuntoMedicion`: gas-entrada-lora resuelve el dispositivo
+ * por `deveui` y no conoce el punto, así que sería un campo sin escritor. Las
+ * recepciones de un punto se consultan por el `deveui` de su dispositivo.
  */
 export const RecepcionUplinkSchema = UltimaRecepcionSchema.extend({
   _id: z.string().optional(),
@@ -72,7 +76,6 @@ export const RecepcionUplinkSchema = UltimaRecepcionSchema.extend({
   idDispositivo: z.string().optional(),
   idLoraServer: z.string().optional(),
   idCliente: z.string().optional(),
-  idPuntoMedicion: z.string().optional(),
   /** Ubicación del dispositivo/punto al momento de la recepción */
   ubicacion: CoordenadasSchema.optional(),
   /** Punto GeoJSON para queries geoespaciales (índice 2dsphere) */


### PR DESCRIPTION
F0 de `PLAN-CONECTIVIDAD-COBERTURA-LORAWAN-V3.md`. **Aditivo y opcional**: mergearlo no cambia el comportamiento de ningún servicio.

## Por qué

Un uplink LoRaWAN no es "el RSSI del dispositivo": es **N recepciones, una por gateway que lo escuchó**. Ese detalle llega hoy a `gas-entrada-lora` en `IUplink.metadatos[]` (gatewayID, rssi, loRaSNR, location por gateway), viaja a la API de device… y **ninguna lo lee**: `gas-sml`, `gas-api-ml107a`, `gas-api-euw300` y `gas-api-nme` no mencionan `rssi` en todo su `src/`.

Consecuencias verificadas:

- `IDispositivo.rssi/snr/dr/adr` están **muertos**. El único escritor de `rssi` en todo el sistema es `gas-api-uwm-nb`, que es NB-IoT y no LoRa. `gas-api-cliente` los popula en el detalle del PM de agua y `gas-datos` los exporta en el padrón: siempre vacíos.
- Lo único que sobrevive del enlace es `logLora.body.rxInfo`, con TTL de 90 días y sin lectura desde el portal del cliente.
- No se puede responder "qué gateways escucharon el último reporte de este punto", que es uno de los tres pedidos de la feature.

## Qué agrega

- **`recepcion-uplink.ts`** — `GatewayRecepcionSchema`, `UltimaRecepcionSchema` (estado del enlace en el último uplink, para embeber) y `RecepcionUplinkSchema` (traza histórica; la colección lleva TTL).
- **`IDispositivo.ultimaRecepcion`** — lo escribe `gas-entrada-lora`, único punto por donde pasan todos los uplinks de los tres network servers. Escribir ahí evita tocar las ~8 APIs de device.
- `rssi`/`snr`/`dr`/`adr` marcados `@deprecated` (se limpian en F6, todavía tienen lectores).
- **`TipoAlerta` suma `"Gateway sin reportar"`**, más `IAlerta.idGatewayLorawan` y su virtual. Es el primer tipo de alerta a nivel infraestructura: no lleva `deveui` ni punto de medición. Hasta ahora un backhaul caído sólo se veía como N puntos "Sin Reportar" — los 3 gateways de ITCSA estuvieron 9 h 19 min caídos sin generar una sola alerta. La abre `gas-cron` **con histéresis** (antecedente: 16.570 alertas por flapping).

## Dos decisiones que no conviene revisar sin releer esto

1. **`distancia` se calcula contra `IGatewayLorawan.ubicacion`, NUNCA contra el `location` de `rxInfo`.** Los gateways hospedados reportan la ubicación estática del packet forwarder: los tres de ITCSA informan Chascomús estando en Mendoza, a 1.000 km. La cobertura actual (`gas-field-tester`) usa `rxInfo` y por eso tiene las distancias mal.
2. **`IRecepcionUplink` no lleva virtuals de populate.** `IDispositivo`/`IPuntoMedicion` son del SCC y un schema real de ese lado cierra el ciclo; lo que hace falta para mostrar la fila va denormalizado. `alerta.ts` sí usa el schema real de `IGatewayLorawan`, que está fuera del SCC.

## Al mergear

Necesita sus `@Prop()` en gas-datos (`dispositivo.model.ts` y `alerta.model.ts`): los schemas son estrictos y sin el `@Prop()` Mongoose descarta el valor **en silencio**. Va en F1.

## Verificación

```
npm run build                                        ok
require('./dist/index.js')                           489 exports
npm run gen:json-schema -- --verbose                 ok=473 skipped=0 error=0
npx madge --circular --extensions js dist/interfaces  0 ciclos
npm test                                             19/19
```