### PR TITLE
feat(punto): datosExternos para el payload de la conexión externa

### DIFF
--- a/src/interfaces/entidades/punto-medicion.ts
+++ b/src/interfaces/entidades/punto-medicion.ts
@@ -62,6 +62,17 @@ export const PuntoMedicionSchema = z.object({
   idCuenta: z.string().nullable().optional(),
   codigoExternoConexion: z.string().optional(),
   codigoExternoInmueble: z.string().optional(),
+  // Payload de la conexión tal como lo entrega el sistema externo, para lo que
+  // no tiene semántica propia en INSIDEht. Espejo del bag que ya tiene
+  // ICuentaCliente para el inmueble.
+  //
+  // Lo que lo hace necesario: el transmisor de una conexión puede venir
+  // declarado en el padrón y NO estar provisionado todavía (el device lo carga
+  // la app móvil, aparte). Hasta ahora ese `trans_mac` no se guardaba en
+  // ninguna parte —el punto quedaba sin medidor y el dato sólo existía en un
+  // log— así que no había forma de vincularlo después ni de decirle al cliente
+  // qué equipo le falta dar de alta. En PROD se perdieron 3 conexiones así.
+  datosExternos: z.record(z.string(), z.any()).optional(),
   diametroConexion: z.number().optional(),
   materialConexion: z.string().optional(),
   facturable: z.boolean().optional(),
@@ -157,6 +168,7 @@ export interface IPuntoMedicion {
   idCuenta?: string | null;
   codigoExternoConexion?: string;
   codigoExternoInmueble?: string;
+  datosExternos?: Record<string, any>;
   diametroConexion?: number;
   materialConexion?: string;
   facturable?: boolean;


### PR DESCRIPTION
## Qué agrega

`IPuntoMedicion.datosExternos?: Record<string, any>` — espejo del bag que **`ICuentaCliente` ya tiene** para el inmueble (`cuenta-cliente.ts:41`). Guarda lo que el sistema externo entrega de la conexión y no tiene semántica propia en INSIDEht.

## Por qué

El transmisor de una conexión puede venir declarado en el padrón y **no estar provisionado todavía**: el device lo carga la app móvil, en un flujo aparte. La ingesta es link-only y en ese caso crea el punto **sin medidor**.

Hasta ahora ese `trans_mac` no se persistía en ninguna parte. El único registro era una línea de log:

```
Conexión con_id=1 (cuenta=05900768990004): transmisor c4cd829f6a6984ce
no provisionado en INSIDEht → PM sin medidor (pendiente).
```

Con eso no hay forma de saber qué transmisor le falta dar de alta al cliente sin ir a buscarlo a los logs, que expiran.

**Ya pasó en PROD con 3 conexiones de AYSAM.** Quedaron sin medidor y los tres deveuis hubo que recuperarlos de Cloud Logging:

| Cuenta | inm_id | con_id | Transmisor faltante |
|---|---|---|---|
| 05900768990004 | 200037764 | 1 | `c4cd829f6a6984ce` |
| 05900790190003 | 200039185 | 1 | `c4cd829f6a6984a3` |
| 05931258530003 | 700163691 | 3 | `c4cd826df2c4cefb` |

## Alcance

Aditivo y opcional: ningún consumidor cambia de comportamiento. Es **sólo persistencia**: que el dato del padrón quede en la base en vez de vivir únicamente en un log.

**No cambia el mecanismo de vinculación.** Que esas tres conexiones dejaran de ofrecerse en el GET es una anomalía del lado de AYSAM —ellos confirmaron que deben seguir mostrándose hasta que las confirmemos— y se corrige allá, no acá. El ACK diferido queda como está.

⚠️ Necesita su `@Prop({ type: Object })` en `gas-datos` — el schema es estricto y sin eso Mongoose descarta el valor en silencio.

## Verificación

`npm run build`, barrel con 489 exports, `gen:json-schema --verbose` (473 ok, 0 error), `madge --circular` sobre `dist` sin ciclos, y `npm test` 19/19.