### PR TITLE
feat(cliente): flag por cliente para el editor de clasificación

### DIFF
--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -147,6 +147,18 @@ export const ModuloClimaSchema = z.object({
 });
 export type IModuloClima = z.infer<typeof ModuloClimaSchema>;
 
+/**
+ * Editor de clasificación de puntos de medición (F5 del modelo canónico).
+ *
+ * Ausente ⇒ apagado. Es una pantalla de administración del padrón que sólo tiene
+ * sentido para el cliente que está haciendo ese trabajo; al resto le muestra una
+ * sección vacía que no sabe para qué es.
+ */
+export const ModuloClasificacionSchema = z.object({
+  activo: z.boolean().optional(),
+});
+export type IModuloClasificacion = z.infer<typeof ModuloClasificacionSchema>;
+
 export const ParametrosObisSchema = z.object({
   reporteMask: z.number().optional(),
 });
@@ -196,6 +208,7 @@ export const ConfigClienteSchema = z.object({
   vistasPersonalizadas: VistasPersonalizadasPorDivisionSchema.optional(),
   moduloCoberturaLorawan: ModuloCoberturaLorawanSchema.optional(),
   moduloClima: ModuloClimaSchema.optional(),
+  moduloClasificacion: ModuloClasificacionSchema.optional(),
   parametrosObis: ParametrosObisSchema.optional(),
   permitirEditarUnNcoAsignado: z.boolean().optional(),
   crearMedidorResidencialAutomatico: z.boolean().optional(),


### PR DESCRIPTION
`config.moduloClasificacion.activo`, con la misma forma que `moduloClima`. **Ausente significa apagado.**

La pantalla de clasificación de puntos (F5) se subió a producción sin gate: `gas-web-cliente v4.14.4` la incluye y quedó visible para **todos** los clientes. Es una herramienta de administración del padrón — sólo tiene sentido para el cliente que está haciendo ese trabajo, y al resto le muestra una sección que no sabe para qué es.

Consumidores:

- `gas-web-cliente` — ítem de menú + guard de ruta, igual que `ModuloClimaGuard`.
- `gas-web-admin` — el toggle en el ABM de clientes, para poder encenderlo sin tocar la base.

`npm run build` y `npm test` (19/19) en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)