### PR TITLE
feat: config de alarmas de agua y tipos de envío para ML107A

### DIFF
--- a/src/interfaces/entidades/envio-sms.ts
+++ b/src/interfaces/entidades/envio-sms.ts
@@ -22,6 +22,15 @@ export const TipoAlertaEnvioSchema = z.enum([
   "VERIBOX - Batería baja",
   "NSP - Batería baja",
   "SCADA - Error de comunicación con servidor",
+  // Medición residencial de agua (módulo ML107A). Las cuatro primeras las dispara
+  // gas-api-ml107a al ABRIR la alerta correspondiente sobre el punto; la de equipos
+  // fuera de línea la dispara gas-cron por porcentaje del parque, igual que sus
+  // equivalentes de NUC/NSP/VERIBOX/SCADA.
+  "Medidor de agua - Fuga",
+  "Medidor de agua - Flujo inverso",
+  "Medidor de agua - Ataque magnético",
+  "Medidor de agua - Batería baja",
+  "ML107A - Equipos fuera de línea",
 ]);
 // El nombre del TIPO se mantiene igual al original (TipoAlerta, sin prefijo I
 // porque nunca fue una interface) — solo la constante *Schema se renombró

--- a/src/interfaces/tenant/cliente.model.ts
+++ b/src/interfaces/tenant/cliente.model.ts
@@ -204,6 +204,31 @@ export const ConfigClienteSchema = z.object({
   nucV3: z.boolean().optional(),
   sobreEscribirRegistrosNuc: z.boolean().optional(),
   valorAlarmaBateriaSml: z.number().optional(),
+  /**
+   * Metros cúbicos mínimos que tiene que crecer el acumulado de flujo inverso de un
+   * medidor residencial de agua, respecto de su lectura anterior, para abrir una
+   * alerta de "Flujo inverso".
+   *
+   * El campo del equipo es un ODÓMETRO (cuenta desde que se puso en servicio y nunca
+   * decrece): un valor > 0 sólo dice que alguna vez hubo contraflujo — le pasa al 67%
+   * del parque. Lo que indica contraflujo activo es el INCREMENTO entre dos lecturas,
+   * y eso es lo que se compara contra este umbral.
+   *
+   * Sin definir, se usa el default del productor (gas-api-ml107a). Campo plano y no
+   * un objeto anidado a propósito: el merge de `config` en gas-admin es SHALLOW.
+   */
+  umbralFlujoInversoAgua: z.number().optional(),
+  /**
+   * Cantidad de lecturas CONSECUTIVAS con la bandera de fuga encendida que hacen
+   * falta para abrir una alerta de "Fuga" en un medidor residencial de agua.
+   *
+   * Existe porque la bandera del equipo alterna: de los 445 equipos que la
+   * encendieron en un relevamiento de 3 días, 247 la prendieron y apagaron. Con 1 el
+   * comportamiento es el del bit crudo (abre y cierra con cada transmisión).
+   *
+   * Sin definir, se usa el default del productor (gas-api-ml107a).
+   */
+  lecturasParaAlertaFugaAgua: z.number().optional(),
   puedeCrearDispositivos: z.boolean().optional(),
   vistasPersonalizadas: VistasPersonalizadasPorDivisionSchema.optional(),
   moduloCoberturaLorawan: ModuloCoberturaLorawanSchema.optional(),


### PR DESCRIPTION
## Qué

Dos cambios, los dos habilitantes de que las alarmas del medidor residencial de agua (módulo ML107A) funcionen de punta a punta.

### 1. `ConfigClienteSchema`: parámetros de las alarmas de agua

| Campo | Qué gobierna |
|---|---|
| `umbralFlujoInversoAgua` | m³ mínimos de **incremento** del acumulado de flujo inverso entre dos lecturas para abrir `Flujo inverso` |
| `lecturasParaAlertaFugaAgua` | lecturas **consecutivas** con la bandera de fuga encendida para abrir `Fuga` |

Por qué hace falta cada uno:

- El acumulado inverso del equipo es un **odómetro**: un valor > 0 sólo dice que alguna vez hubo contraflujo, y lo tiene el 67% del parque productivo. Lo que indica contraflujo activo es el incremento entre lecturas — medido, los equipos con incremento real son 5, con deltas de 0,01 a 0,02 m³.
- La bandera de fuga **alterna**: de 445 equipos que la encendieron en 3 días, 247 la prendieron y apagaron. Abrir con el bit crudo haría oscilar el semáforo de esos 247.

Campos planos, no un objeto anidado: el merge de `config` en gas-admin es shallow y un objeto se pisaría entero en cada PUT.

### 2. `TipoAlertaEnvioSchema`: categorías de agua

El enum tenía 13 valores, todos de Presión/NSP/NUC/VERIBOX/SCADA. Un cliente cuyo `tiposDispositivo` es sólo `ML107A` no tiene **ningún** tipo elegible, así que el combo "Tipo de Alarma" de Notificaciones queda vacío y no se puede crear una configuración de envío.

Se agregan cinco: `Medidor de agua - Fuga`, `- Flujo inverso`, `- Ataque magnético`, `- Batería baja` (las dispara gas-api-ml107a al abrir la alerta) y `ML107A - Equipos fuera de línea` (la dispara gas-cron por porcentaje del parque, igual que sus equivalentes de NUC/NSP/VERIBOX/SCADA; el bucket `ml107a` de `CantidadPorEstado` ya existe y hoy no lo consume nadie).

## Consumidores que vienen detrás

Este PR va primero; los demás se abren cuando esté mergeado y con `npm run modelos` corrido:

- **gas-api-ml107a**: apertura y cierre de las cuatro alertas + fix del dispatch por longitud en el puerto 223 + notificaciones.
- **gas-cron**: consumo del bucket `ml107a` en equipos fuera de línea.
- **gas-api-cliente**: endpoint de update de los dos parámetros.
- **gas-web-cliente**: pantalla de configuración y rama de agua en el combo de tipos de alarma.

## Verificación

`npm test` (build + 19 tests) en verde.